### PR TITLE
feat: add cel to ast parser

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,9 +9,6 @@ jobs:
   build_and_test_rust:
     name: Build and Test Rust
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ic-response-verification-rs
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,6 +28,7 @@ jobs:
         run: cargo test --lib
 
       - name: Wasm test
+        working-directory: ic-response-verification-rs
         run: wasm-pack test --node
 
       - name: Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,10 @@ checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cel-parser"
-version = "0.1.0"
+version = "0.0.0"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"

--- a/cel-parser/Cargo.toml
+++ b/cel-parser/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "cel-parser"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+nom = "7.1.1"

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -1,31 +1,12 @@
 #![allow(dead_code, unused_variables, unused_imports, unused_imports)]
 
 mod mock;
+mod model;
+mod parser;
+
+pub use model::*;
+
 use mock::*;
-
-struct RequestCertification {
-    certified_request_headers: Vec<String>,
-    certified_query_parameters: Vec<String>,
-}
-
-enum ResponseCertification {
-    HeaderExclusions(Vec<String>),
-    CertifiedHeaders(Vec<String>),
-}
-
-struct Certification {
-    request_certification: Option<RequestCertification>,
-    response_certification: ResponseCertification,
-}
-
-impl Certification {
-    fn new() -> Self {
-        Certification {
-            request_certification: None,
-            response_certification: ResponseCertification::HeaderExclusions(vec![]),
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/cel-parser/src/model.rs
+++ b/cel-parser/src/model.rs
@@ -1,0 +1,23 @@
+pub struct RequestCertification {
+    pub certified_request_headers: Vec<String>,
+    pub certified_query_parameters: Vec<String>,
+}
+
+pub enum ResponseCertification {
+    HeaderExclusions(Vec<String>),
+    CertifiedHeaders(Vec<String>),
+}
+
+pub struct Certification {
+    pub request_certification: Option<RequestCertification>,
+    pub response_certification: ResponseCertification,
+}
+
+impl Certification {
+    fn new() -> Self {
+        Certification {
+            request_certification: None,
+            response_certification: ResponseCertification::HeaderExclusions(vec![]),
+        }
+    }
+}

--- a/cel-parser/src/parser.rs
+++ b/cel-parser/src/parser.rs
@@ -1,0 +1,363 @@
+use crate::Certification;
+use nom::branch::alt;
+use nom::bytes::complete::{escaped, tag, take_till, take_until, take_while};
+use nom::character::complete::{alphanumeric1, char, multispace0, one_of};
+use nom::character::is_alphanumeric;
+use nom::combinator::{cut, eof, map};
+use nom::error::{context, convert_error, ContextError, Error, ParseError, VerboseError};
+use nom::multi::separated_list0;
+use nom::sequence::{delimited, preceded, separated_pair, terminated, tuple};
+use nom::{AsChar, IResult, InputIter, Parser, Slice};
+use std::collections::HashMap;
+use std::ops::RangeFrom;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum CelValue {
+    String(String),
+    Array(Vec<CelValue>),
+    Object(String, HashMap<String, CelValue>),
+    Function(String, Vec<CelValue>),
+}
+
+fn trim_whitespace<'a, O, P, E: ParseError<&'a str> + ContextError<&'a str>>(
+    parser: P,
+) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    P: Parser<&'a str, O, E>,
+{
+    context("trim_whitespace", preceded(multispace0, parser))
+}
+
+fn drop_separators<'a, O, P, E: ParseError<&'a str> + ContextError<&'a str>>(
+    opening_separator: char,
+    closing_separator: char,
+    parser: P,
+) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    P: Parser<&'a str, O, E>,
+{
+    context(
+        "drop_separators",
+        preceded(
+            trim_whitespace(char(opening_separator)),
+            cut(terminated(parser, trim_whitespace(char(closing_separator)))),
+        ),
+    )
+}
+
+fn ident<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, String, E> {
+    let acceptable_special_chars = "_";
+
+    context(
+        "parse_ident",
+        map(
+            take_while(move |e| acceptable_special_chars.contains(e) || is_alphanumeric(e as u8)),
+            String::from,
+        ),
+    )(i)
+}
+
+fn parse_str<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, String, E> {
+    let acceptable_special_chars = "-";
+
+    context(
+        "parse_str",
+        map(
+            escaped(
+                take_while(move |e| {
+                    acceptable_special_chars.contains(e) || is_alphanumeric(e as u8)
+                }),
+                '\\',
+                one_of("\"n\\"),
+            ),
+            String::from,
+        ),
+    )(i)
+}
+
+fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, String, E> {
+    context("string", drop_separators('\"', '\"', parse_str))(i)
+}
+
+fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, Vec<CelValue>, E> {
+    context(
+        "array",
+        drop_separators(
+            '[',
+            ']',
+            separated_list0(trim_whitespace(char(',')), cel_value),
+        ),
+    )(i)
+}
+
+fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, (String, CelValue), E> {
+    context(
+        "key_value",
+        separated_pair(
+            trim_whitespace(ident),
+            trim_whitespace(char(':')),
+            cel_value,
+        ),
+    )(i)
+}
+
+fn object<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, (String, HashMap<String, CelValue>), E> {
+    context(
+        "object",
+        tuple((
+            ident,
+            drop_separators(
+                '{',
+                '}',
+                map(
+                    separated_list0(trim_whitespace(char(',')), key_value),
+                    |tuple_vec| tuple_vec.into_iter().collect(),
+                ),
+            ),
+        )),
+    )(i)
+}
+
+fn function<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, (String, Vec<CelValue>), E> {
+    context(
+        "function",
+        tuple((
+            ident,
+            drop_separators(
+                '(',
+                ')',
+                map(
+                    separated_list0(trim_whitespace(char(',')), cel_value),
+                    |tuple_vec| tuple_vec.into_iter().collect(),
+                ),
+            ),
+        )),
+    )(i)
+}
+
+fn cel_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    i: &'a str,
+) -> IResult<&'a str, CelValue, E> {
+    trim_whitespace(alt((
+        map(object, |(name, value)| CelValue::Object(name, value)),
+        map(function, |(name, value)| CelValue::Function(name, value)),
+        map(array, CelValue::Array),
+        map(string, CelValue::String),
+    )))(i)
+}
+
+// [TODO] - Create concrete error type instead of just "String"
+pub fn parse_cel_expression(i: &str) -> Result<CelValue, String> {
+    // [TODO] - Create "debug" feature flag to toggle on verbose errors
+    let result = cel_value::<VerboseError<&str>>(i);
+
+    match result {
+        Err(nom::Err::Error(e)) | Err(nom::Err::Failure(e)) => {
+            // [TODO] - Create "debug" feature flag to toggle on stacktrace
+            let stacktrace = convert_error(i, e);
+
+            Err(stacktrace)
+        }
+        Err(e) => Err(e.to_string()),
+        Ok((_remaining, result)) => Ok(result),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom::error::{convert_error, VerboseError};
+
+    #[test]
+    fn parses_no_certification_expression() {
+        let cel_expression = r#"
+            default_certification (
+              ValidationArgs {
+                no_certification: Empty { }
+              }
+            )
+        "#;
+
+        let result = parse_cel_expression(cel_expression).unwrap();
+
+        assert_eq!(
+            result,
+            CelValue::Function(
+                "default_certification".into(),
+                vec![CelValue::Object(
+                    "ValidationArgs".into(),
+                    HashMap::from([(
+                        "no_certification".into(),
+                        CelValue::Object("Empty".into(), HashMap::from([]))
+                    )]),
+                )],
+            )
+        );
+    }
+
+    #[test]
+    fn parses_no_request_certification_expression() {
+        let cel_expression = r#"
+            default_certification (
+              ValidationArgs {
+                certification: Certification {
+                  no_request_certification: Empty {},
+                  response_certification: ResponseCertification {
+                    response_header_exclusions: ResponseHeaderList {
+                      headers: ["Server","Date","X-Cache-Status"]
+                    }
+                  }
+                }
+              }
+            )
+        "#;
+
+        let result = parse_cel_expression(cel_expression).unwrap();
+
+        assert_eq!(
+            result,
+            CelValue::Function(
+                "default_certification".into(),
+                vec![CelValue::Object(
+                    "ValidationArgs".into(),
+                    HashMap::from([(
+                        "certification".into(),
+                        CelValue::Object(
+                            "Certification".into(),
+                            HashMap::from([
+                                (
+                                    "no_request_certification".into(),
+                                    CelValue::Object("Empty".into(), HashMap::from([]))
+                                ),
+                                (
+                                    "response_certification".into(),
+                                    CelValue::Object(
+                                        "ResponseCertification".into(),
+                                        HashMap::from([(
+                                            "response_header_exclusions".into(),
+                                            CelValue::Object(
+                                                "ResponseHeaderList".into(),
+                                                HashMap::from([(
+                                                    "headers".into(),
+                                                    CelValue::Array(vec![
+                                                        CelValue::String("Server".into()),
+                                                        CelValue::String("Date".into()),
+                                                        CelValue::String("X-Cache-Status".into()),
+                                                    ])
+                                                )]),
+                                            )
+                                        )]),
+                                    )
+                                )
+                            ]),
+                        )
+                    )]),
+                )],
+            )
+        );
+    }
+
+    #[test]
+    fn parses_full_certification_expression() {
+        let cel_expression = r#"
+            default_certification (
+                ValidationArgs {
+                    certification: Certification {
+                        request_certification: RequestCertification {
+                            certified_request_headers: ["host"],
+                            certified_query_parameters: ["filter"]
+                        },
+                        response_certification: ResponseCertification {
+                            certified_response_headers: ResponseHeaderList {
+                                headers: ["Content-Type","X-Frame-Options","Content-Security-Policy","Strict-Transport-Security","Referrer-Policy","Permissions-Policy"]
+                            }
+                        }
+                    }
+                }
+            )
+        "#;
+
+        let result = parse_cel_expression(cel_expression).unwrap();
+
+        assert_eq!(
+            result,
+            CelValue::Function(
+                "default_certification".into(),
+                vec![CelValue::Object(
+                    "ValidationArgs".into(),
+                    HashMap::from([(
+                        "certification".into(),
+                        CelValue::Object(
+                            "Certification".into(),
+                            HashMap::from([
+                                (
+                                    "request_certification".into(),
+                                    CelValue::Object(
+                                        "RequestCertification".into(),
+                                        HashMap::from([
+                                            (
+                                                "certified_request_headers".into(),
+                                                CelValue::Array(vec![CelValue::String(
+                                                    "host".into()
+                                                )])
+                                            ),
+                                            (
+                                                "certified_query_parameters".into(),
+                                                CelValue::Array(vec![CelValue::String(
+                                                    "filter".into()
+                                                )])
+                                            ),
+                                        ]),
+                                    )
+                                ),
+                                (
+                                    "response_certification".into(),
+                                    CelValue::Object(
+                                        "ResponseCertification".into(),
+                                        HashMap::from([(
+                                            "certified_response_headers".into(),
+                                            CelValue::Object(
+                                                "ResponseHeaderList".into(),
+                                                HashMap::from([(
+                                                    "headers".into(),
+                                                    CelValue::Array(vec![
+                                                        CelValue::String("Content-Type".into()),
+                                                        CelValue::String("X-Frame-Options".into()),
+                                                        CelValue::String(
+                                                            "Content-Security-Policy".into()
+                                                        ),
+                                                        CelValue::String(
+                                                            "Strict-Transport-Security".into()
+                                                        ),
+                                                        CelValue::String("Referrer-Policy".into()),
+                                                        CelValue::String(
+                                                            "Permissions-Policy".into()
+                                                        ),
+                                                    ])
+                                                )]),
+                                            )
+                                        )]),
+                                    )
+                                )
+                            ]),
+                        )
+                    )]),
+                )],
+            )
+        );
+    }
+}


### PR DESCRIPTION
This is part 1 of the CEL parser. It accepts a string and outputs (for lack of a better term) an AST. In the next PR I'll take that AST and convert it into well defined types that can be safely used in the response verification.