### PR TITLE
feat: add CEL ast to certification object validation and mapping

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo build --release
 
       - name: Test
-        run: cargo test --lib
+        run: cargo test
 
       - name: Wasm test
         working-directory: ic-response-verification-rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ name = "cel-parser"
 version = "0.0.0"
 dependencies = [
  "nom",
+ "thiserror",
 ]
 
 [[package]]
@@ -465,6 +466,7 @@ dependencies = [
  "http",
  "ic-certification",
  "js-sys",
+ "leb128",
  "nom",
  "serde_cbor",
  "sha2 0.10.6",
@@ -1027,18 +1029,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cel-parser/Cargo.toml
+++ b/cel-parser/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 nom = "7.1.1"
+thiserror = "1.0.38"

--- a/cel-parser/src/ast_mapping.rs
+++ b/cel-parser/src/ast_mapping.rs
@@ -1,0 +1,191 @@
+use crate::error::{CelParserError, CelParserResult};
+use crate::parser::CelValue;
+use crate::{Certification, RequestCertification, ResponseCertification};
+use std::collections::HashMap;
+
+fn validate_object<'a>(
+    cel: &'a CelValue,
+    name: &str,
+) -> CelParserResult<&'a HashMap<String, CelValue>> {
+    let CelValue::Object(object_name, object_value) = cel else {
+        return Err(CelParserError::UnexpectedNodeType {
+            node_name: name.into(),
+            expected_type: "Object".into(),
+            found_type: cel.to_string(),
+        });
+    };
+
+    if object_name != name {
+        return Err(CelParserError::UnexpectedNodeName {
+            node_type: "Object".into(),
+            expected_name: name.into(),
+            found_name: object_name.into(),
+        });
+    }
+
+    Ok(object_value)
+}
+
+fn validate_function<'a>(cel: &'a CelValue, name: &str) -> CelParserResult<&'a Vec<CelValue>> {
+    let CelValue::Function(function_name, function_value) = cel else {
+        return Err(CelParserError::UnexpectedNodeType {
+            node_name: name.into(),
+            expected_type: "Function".into(),
+            found_type: cel.to_string(),
+        });
+    };
+
+    if function_name != name {
+        return Err(CelParserError::UnexpectedNodeName {
+            node_type: "Function".into(),
+            expected_name: name.into(),
+            found_name: function_name.into(),
+        });
+    }
+
+    Ok(function_value)
+}
+
+fn validate_string_array(cel: &CelValue, name: &str) -> CelParserResult<Vec<String>> {
+    let CelValue::Array(array) = cel else {
+        return Err(CelParserError::UnexpectedNodeType {
+            node_name: name.into(),
+            expected_type: "Array".into(),
+            found_type: cel.to_string(),
+        });
+    };
+
+    let elements = array
+        .iter()
+        .map(|e| {
+            let CelValue::String(e) = e else {
+                return Err(CelParserError::UnexpectedNodeType {
+                    node_name: name.into(),
+                    expected_type: "String".into(),
+                    found_type: cel.to_string(),
+                });
+            };
+
+            Ok(e.to_owned())
+        })
+        .collect::<Result<_, _>>()?;
+
+    Ok(elements)
+}
+
+fn validate_request_certification(
+    certification: &HashMap<String, CelValue>,
+) -> CelParserResult<Option<RequestCertification>> {
+    let no_request_certification = certification.get("no_request_certification");
+    let request_certification = certification.get("request_certification");
+
+    return match (no_request_certification, request_certification) {
+        (Some(_), Some(_)) => Err(CelParserError::ExtraneousRequestCertificationProperty),
+        (None, None) => Err(CelParserError::MissingRequestCertificationProperty),
+        (Some(_), None) => Ok(None),
+        (None, Some(request_certification)) => {
+            let request_certification =
+                validate_object(request_certification, "RequestCertification")?;
+
+            let Some(certified_request_headers) = request_certification.get("certified_request_headers") else {
+                return Err(CelParserError::MissingObjectProperty {
+                    object_name: "RequestCertification".into(),
+                    expected_property_name: "certified_request_headers".into(),
+                });
+            };
+            let certified_request_headers =
+                validate_string_array(certified_request_headers, "certified_request_headers")?;
+
+            let Some(certified_query_parameters) = request_certification.get("certified_query_parameters") else {
+                return Err(CelParserError::MissingObjectProperty {
+                    object_name: "RequestCertification".into(),
+                    expected_property_name: "certified_query_parameters".into(),
+                });
+            };
+            let certified_query_parameters =
+                validate_string_array(certified_query_parameters, "certified_query_parameters")?;
+
+            Ok(Some(RequestCertification {
+                certified_request_headers,
+                certified_query_parameters,
+            }))
+        }
+    };
+}
+
+fn validate_response_certification(
+    certification: &HashMap<String, CelValue>,
+) -> CelParserResult<ResponseCertification> {
+    let Some(response_certification) = certification.get("response_certification") else {
+        return Err(CelParserError::MissingObjectProperty {
+            object_name: "RequestCertification".into(),
+            expected_property_name: "response_certification".into(),
+        });
+    };
+    let response_certification = validate_object(response_certification, "ResponseCertification")?;
+
+    let get_response_certification_headers =
+        |property_name| -> CelParserResult<Option<Vec<String>>> {
+            response_certification
+                .get(property_name)
+                .and_then(|certified_response_headers| {
+                    Some(validate_object(
+                        certified_response_headers,
+                        "ResponseHeaderList",
+                    ))
+                })
+                .transpose()?
+                .and_then(|certified_response_headers| certified_response_headers.get("headers"))
+                .and_then(|headers| Some(validate_string_array(headers, property_name)))
+                .transpose()
+        };
+
+    let certified_response_headers =
+        get_response_certification_headers("certified_response_headers")?;
+
+    let response_header_exclusions =
+        get_response_certification_headers("response_header_exclusions")?;
+
+    return match (certified_response_headers, response_header_exclusions) {
+        (Some(_), Some(_)) => Err(CelParserError::ExtraneousResponseCertificationProperty),
+        (None, None) => Err(CelParserError::MissingResponseCertificationProperty),
+        (Some(headers), None) => Ok(ResponseCertification::CertifiedHeaders(headers)),
+        (None, Some(headers)) => Ok(ResponseCertification::HeaderExclusions(headers)),
+    };
+}
+
+pub fn map_cel_ast(cel: CelValue) -> CelParserResult<Option<Certification>> {
+    let default_certification = validate_function(&cel, "default_certification")?;
+
+    let Some(validation_args) = default_certification.get(0) else {
+        return Err(CelParserError::MissingFunctionParameter {
+            function_name: "default_certification".into(),
+            parameter_name: "ValidationArgs".into(),
+            parameter_type: "Object".into(),
+            parameter_position: 0,
+        });
+    };
+
+    let validation_args = validate_object(validation_args, "ValidationArgs")?;
+
+    let no_certification = validation_args.get("no_certification");
+    let certification = validation_args.get("certification");
+
+    return match (no_certification, certification) {
+        (Some(_), Some(_)) => Err(CelParserError::ExtraneousValidationArgsProperty),
+        (None, None) => Err(CelParserError::MissingValidationArgsProperty),
+        (Some(_), None) => Ok(None),
+        (None, Some(certification)) => {
+            let certification = validate_object(certification, "Certification")?;
+
+            let request_certification = validate_request_certification(certification)?;
+
+            let response_certification = validate_response_certification(certification)?;
+
+            Ok(Some(Certification {
+                request_certification,
+                response_certification,
+            }))
+        }
+    };
+}

--- a/cel-parser/src/error.rs
+++ b/cel-parser/src/error.rs
@@ -1,0 +1,65 @@
+pub type CelParserResult<T = ()> = Result<T, CelParserError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CelParserError {
+    #[error(r#""{0}" is not a supported CEL function, only default_certification is currently supported"#)]
+    UnrecognizedFunction(String),
+
+    #[error(r#"Parameter at position {parameter_position:?} for function {function_name:?} is missing, expected {parameter_name:?} with type {parameter_type:?}"#)]
+    MissingFunctionParameter {
+        function_name: String,
+        parameter_type: String,
+        parameter_name: String,
+        parameter_position: u8,
+    },
+
+    #[error(r#"Parameter at position {parameter_position:?} for function {function_name:?} has the wrong type, expected {parameter_name:?} {expected_parameter_type:?} found {found_parameter_type:?}"#)]
+    IncorrectFunctionParameterType {
+        function_name: String,
+        parameter_name: String,
+        expected_parameter_type: String,
+        found_parameter_type: String,
+        parameter_position: u8,
+    },
+
+    #[error(r#"Expected node with name {node_name:?} to have type {expected_type:?}, found {found_type:?}"#)]
+    UnexpectedNodeType {
+        node_name: String,
+        expected_type: String,
+        found_type: String,
+    },
+
+    #[error(r#"Expected node with type {node_type:?} to have name {expected_name:?}, found {found_name:?}"#)]
+    UnexpectedNodeName {
+        node_type: String,
+        expected_name: String,
+        found_name: String,
+    },
+
+    #[error(r#"Expected object {object_name:?} to have property {expected_property_name:?}"#)]
+    MissingObjectProperty {
+        object_name: String,
+        expected_property_name: String,
+    },
+
+    #[error(r#"The request_certification object must only specify one of the no_request_certification or request_certification properties, not both"#)]
+    ExtraneousRequestCertificationProperty,
+
+    #[error(r#"The request_certification object must specify at least one of the no_request_certification or request_certification properties"#)]
+    MissingRequestCertificationProperty,
+
+    #[error(r#"The response_certification object must only specify one of the certified_response_headers or response_header_exclusions properties, not both"#)]
+    ExtraneousResponseCertificationProperty,
+
+    #[error(r#"The response_certification object must specify at least one of the certified_response_headers or response_header_exclusions properties"#)]
+    MissingResponseCertificationProperty,
+
+    #[error(r#"The ValidationArgs parameter must only specify one of the no_certification or certification properties, not both"#)]
+    ExtraneousValidationArgsProperty,
+
+    #[error(r#"The ValidationArgs parameter must specify at least one of the no_certification or certification properties"#)]
+    MissingValidationArgsProperty,
+
+    #[error(r#"Cel Syntax Expception: {0}"#)]
+    CelSyntaxException(String),
+}

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -1,17 +1,18 @@
 #![allow(dead_code, unused_variables, unused_imports, unused_imports)]
 
+mod ast_mapping;
+mod error;
 mod mock;
 mod model;
 mod parser;
 
 pub use model::*;
 
+use crate::ast_mapping::map_cel_ast;
+use crate::error::{CelParserError, CelParserResult};
+use crate::parser::parse_cel_expression;
 use mock::*;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {}
+pub fn cel_to_certification(cel: &str) -> CelParserResult<Option<Certification>> {
+    parse_cel_expression(cel).and_then(map_cel_ast)
 }

--- a/cel-parser/src/model.rs
+++ b/cel-parser/src/model.rs
@@ -1,13 +1,16 @@
+#[derive(Debug, Eq, PartialEq)]
 pub struct RequestCertification {
     pub certified_request_headers: Vec<String>,
     pub certified_query_parameters: Vec<String>,
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub enum ResponseCertification {
     HeaderExclusions(Vec<String>),
     CertifiedHeaders(Vec<String>),
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub struct Certification {
     pub request_certification: Option<RequestCertification>,
     pub response_certification: ResponseCertification,

--- a/cel-parser/tests/cel_to_certification.rs
+++ b/cel-parser/tests/cel_to_certification.rs
@@ -1,0 +1,96 @@
+use cel_parser::{
+    cel_to_certification, Certification, RequestCertification, ResponseCertification,
+};
+
+fn remove_whitespace(s: &str) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+fn assert_parse_result(cel_expression: &str, expected_result: Option<Certification>) {
+    let minified_cel_expression = &remove_whitespace(cel_expression);
+
+    let result = cel_to_certification(cel_expression).unwrap();
+    let minified_result = cel_to_certification(minified_cel_expression).unwrap();
+
+    assert_eq!(result, expected_result);
+    assert_eq!(minified_result, expected_result);
+}
+
+#[test]
+fn parses_no_certification_expression() {
+    let cel_expression = r#"
+            default_certification (
+              ValidationArgs {
+                no_certification: Empty { }
+              }
+            )
+        "#;
+    let expected_result = None;
+
+    assert_parse_result(cel_expression, expected_result);
+}
+
+#[test]
+fn parses_no_request_certification_expression() {
+    let cel_expression = r#"
+            default_certification (
+              ValidationArgs {
+                certification: Certification {
+                  no_request_certification: Empty {},
+                  response_certification: ResponseCertification {
+                    response_header_exclusions: ResponseHeaderList {
+                      headers: ["Server","Date","X-Cache-Status"]
+                    }
+                  }
+                }
+              }
+            )
+        "#;
+    let expected_result = Some(Certification {
+        request_certification: None,
+        response_certification: ResponseCertification::HeaderExclusions(vec![
+            "Server".into(),
+            "Date".into(),
+            "X-Cache-Status".into(),
+        ]),
+    });
+
+    assert_parse_result(cel_expression, expected_result);
+}
+
+#[test]
+fn parses_full_certification_expression() {
+    let cel_expression = r#"
+            default_certification (
+                ValidationArgs {
+                    certification: Certification {
+                        request_certification: RequestCertification {
+                            certified_request_headers: ["host"],
+                            certified_query_parameters: ["filter"]
+                        },
+                        response_certification: ResponseCertification {
+                            certified_response_headers: ResponseHeaderList {
+                                headers: ["Content-Type","X-Frame-Options","Content-Security-Policy","Strict-Transport-Security","Referrer-Policy","Permissions-Policy"]
+                            }
+                        }
+                    }
+                }
+            )
+        "#;
+    let expected_result = Some(Certification {
+        request_certification: Some(RequestCertification {
+            certified_request_headers: vec!["host".into()],
+            certified_query_parameters: vec!["filter".into()],
+        }),
+        response_certification: ResponseCertification::CertifiedHeaders(vec![
+            "Content-Type".into(),
+            "X-Frame-Options".into(),
+            "Content-Security-Policy".into(),
+            "Strict-Transport-Security".into(),
+            "Referrer-Policy".into(),
+            "Permissions-Policy".into(),
+        ]),
+    });
+
+    assert_parse_result(cel_expression, expected_result);
+}

--- a/ic-response-verification-rs/src/certificate_header.rs
+++ b/ic-response-verification-rs/src/certificate_header.rs
@@ -9,10 +9,6 @@ pub struct CertificateHeader {
 
 impl CertificateHeader {
     /// Parses the given header and returns a new CertificateHeader.
-    ///
-    /// ```
-    /// let certificate_header = CertificateHeader::from("certificate=:SGVsbG8gQ2VydGlmaWNhdGUh:,tree=:SGVsbG8gVHJlZSE=:");
-    /// ```
     pub fn from(header_value: &str) -> CertificateHeader {
         let mut certificate_header = CertificateHeader {
             certificate: None,

--- a/ic-response-verification-rs/src/certificate_header_field.rs
+++ b/ic-response-verification-rs/src/certificate_header_field.rs
@@ -12,10 +12,6 @@ pub struct CertificateHeaderField<'a>(pub &'a str, pub Vec<u8>);
 
 impl<'a> CertificateHeaderField<'a> {
     /// Parses the given header field string and returns a new CertificateHeaderField.
-    ///
-    /// ```
-    /// let certificate_header_field = CertificateHeaderField::from("certificate=:SGVsbG8gQ2VydGlmaWNhdGUh:");
-    /// ```
     pub fn from(header_field: &'a str) -> Option<CertificateHeaderField<'a>> {
         if let Some((name, encoded_value)) = extract_header_field(header_field.trim()) {
             if let Some(value) = decode_header_field_value(name, encoded_value) {

--- a/ic-response-verification-rs/src/error.rs
+++ b/ic-response-verification-rs/src/error.rs
@@ -1,4 +1,3 @@
-use crate::error;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
This PR adds the mapping of CEL AST to an actual, usable Rust object.

An extra bit of refactoring I did was move the unit tests for CEL string -> CEL AST into integration tests so now we're just testing CEL string -> Rust object and not the intermediate step, I think this will be much easier maintain than having 2 sets of unit tests:
- CEL string -> CEL AST
- CEL AST -> Rust object