### PR TITLE
fix: representation independant hash should allow for duplicate keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 name = "representation-independent-hashing"
 version = "0.0.0"
 dependencies = [
+ "hex",
  "sha2",
 ]
 

--- a/representation-independent-hashing/Cargo.toml
+++ b/representation-independent-hashing/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 sha2 = "0.10.6"
+
+[dev-dependencies]
+hex = "0.4.3"


### PR DESCRIPTION
A `hashmap` won't allow for duplicate keys. So in [this PR](https://github.com/dfinity/response-verification/pull/24/files#diff-582641c1929b0f5f5ad4797b6e50f5a9eae96e870b5da8ca269689fd2f62ac94R29), if there is duplicate headers then only the last inserted header will be included in the hash.

Also refactored the tests to use `hex:decode("${hexString}")` instead of `u8` arrays, based on @frederikrothenberger's feedback in the same PR (but applied to different tests).