### PR TITLE
feat: add support for numbers in representation independent hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ name = "representation-independent-hashing"
 version = "0.0.0"
 dependencies = [
  "hex",
+ "leb128",
  "sha2",
 ]
 

--- a/representation-independent-hashing/Cargo.toml
+++ b/representation-independent-hashing/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+leb128 = "0.2.5"
 sha2 = "0.10.6"
 
 [dev-dependencies]

--- a/representation-independent-hashing/src/representation_independent_hash.rs
+++ b/representation-independent-hashing/src/representation_independent_hash.rs
@@ -1,13 +1,19 @@
 use crate::hash::hash;
 use sha2::{Digest, Sha256};
 
-/// A partial implementation of [`Representation Independent Hash`] that only supports UTF-8 strings as values.
+pub enum Value {
+    String(String),
+    Number(u64),
+}
+
+/// A partial implementation of [`Representation Independent Hash`] that only supports
+/// UTF-8 strings or numbers as values.
 ///
 /// [`Representation Independent Hash`]: https://internetcomputer.org/docs/current/references/ic-interface-spec/#hash-of-map
-pub fn representation_independent_hash(map: &Vec<(String, String)>) -> [u8; 32] {
+pub fn representation_independent_hash(map: &Vec<(String, Value)>) -> [u8; 32] {
     let mut hashes: Vec<_> = map
         .iter()
-        .map(|(key, value)| (hash(key.as_bytes()), hash(value.as_bytes())))
+        .map(|(key, value)| (hash(key.as_bytes()), hash_value(value)))
         .collect();
 
     hashes.sort_unstable();
@@ -21,18 +27,30 @@ pub fn representation_independent_hash(map: &Vec<(String, String)>) -> [u8; 32] 
     hasher.finalize().into()
 }
 
+fn hash_value(value: &Value) -> [u8; 32] {
+    match value {
+        Value::String(value) => hash(value.as_bytes()),
+        Value::Number(value) => {
+            let mut hasher = Sha256::new();
+            leb128::write::unsigned(&mut hasher, value.to_owned()).unwrap();
+            hasher.finalize().into()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn hash_key_value_map() {
-        let map: Vec<(String, String)> = vec![
-            ("name".into(), "foo".into()),
-            ("message".into(), "Hello World!".into()),
+        let map: Vec<(String, Value)> = vec![
+            ("name".into(), Value::String("foo".into())),
+            ("message".into(), Value::String("Hello World!".into())),
+            ("answer".into(), Value::Number(42)),
         ];
         let expected_hash =
-            hex::decode("5a96cb30cabb504654358b7d726b3d7e2d6cc8f4f33aa27aaa5189158115cacc")
+            hex::decode("b0c6f9191e37dceafdfc47fbfc7e9cc95f21c7b985c2f7ba5855015c2a8f13ac")
                 .unwrap();
 
         let result = representation_independent_hash(&map);
@@ -42,10 +60,10 @@ mod tests {
 
     #[test]
     fn handles_duplicate_keys() {
-        let map: Vec<(String, String)> = vec![
-            ("name".into(), "foo".into()),
-            ("name".into(), "bar".into()),
-            ("message".into(), "Hello World!".into()),
+        let map: Vec<(String, Value)> = vec![
+            ("name".into(), Value::String("foo".into())),
+            ("name".into(), Value::String("bar".into())),
+            ("message".into(), Value::String("Hello World!".into())),
         ];
         let expected_hash =
             hex::decode("435f77c9bdeca5dba4a4b8a34e4f732b4311f1fc252ec6d4e8ee475234b170f9")
@@ -58,15 +76,15 @@ mod tests {
 
     #[test]
     fn hash_reordered_key_value_map() {
-        let map: Vec<(String, String)> = vec![
-            ("name".into(), "foo".into()),
-            ("message".into(), "Hello World!".into()),
-            ("name".into(), "bar".into()),
+        let map: Vec<(String, Value)> = vec![
+            ("name".into(), Value::String("foo".into())),
+            ("message".into(), Value::String("Hello World!".into())),
+            ("name".into(), Value::String("bar".into())),
         ];
-        let reordered_map: Vec<(String, String)> = vec![
-            ("message".into(), "Hello World!".into()),
-            ("name".into(), "bar".into()),
-            ("name".into(), "foo".into()),
+        let reordered_map: Vec<(String, Value)> = vec![
+            ("message".into(), Value::String("Hello World!".into())),
+            ("name".into(), Value::String("bar".into())),
+            ("name".into(), Value::String("foo".into())),
         ];
 
         let result = representation_independent_hash(&map);


### PR DESCRIPTION
Adds support for numbers in the RI Hash function.
Namely for the status code of the response.