### PR TITLE
ci: run e2e tests in parallel on CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,6 +13,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Cargo Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -31,14 +42,43 @@ jobs:
         working-directory: packages/ic-response-verification
         run: wasm-pack test --node
 
-      - name: e2e tests
-        run: ./scripts/e2e.sh
-
       - name: Lint
         run: cargo clippy
 
       - name: Check Formatting
         run: cargo fmt --all -- --check
+
+  e2e_tests:
+    name: e2e Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Cargo e2e Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-e2e-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup e2e Deps Cache
+        uses: actions/cache@v3
+        with:
+          path: tmp/
+          key: ${{ runner.os }}-tmp
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: e2e tests
+        run: ./scripts/e2e.sh
 
   build_npm_package:
     name: Build NPM Package


### PR DESCRIPTION
Our build is starting to take some time to complete, running the e2e tests in parallel and adding caching should help this. The longest task in the build takes ~14mins.

Here's a run with the e2e tests in parallel without caching, even with caching we'll see runtimes like this when we miss the cache: https://github.com/dfinity/response-verification/actions/runs/3967434758/jobs/6799390757
- e2e tests took ~9mins
- rust build & test took ~7.5mins

So this is ~5mins improvement.

Here's a run with a cache hit: https://github.com/dfinity/response-verification/actions/runs/3967853103
- e2e tests took ~3mins
- rust build & test took ~1mins

So that's ~11mins improvement on cache hits.
