### PR TITLE
feat: verify request & response hashes in tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "ic-certification"
 version = "0.23.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=60f7a0d#60f7a0db21688ca423dee0bb150e142a03e925c6"
+source = "git+https://github.com/dfinity/agent-rs?rev=815ee1f#815ee1f523d498d8777a8941acf1a6042f959afc"
 dependencies = [
  "hex",
  "serde",
@@ -818,7 +818,7 @@ dependencies = [
  "flate2",
  "hex",
  "http",
- "ic-certification 0.23.0 (git+https://github.com/dfinity/agent-rs?rev=60f7a0d)",
+ "ic-certification 0.23.0 (git+https://github.com/dfinity/agent-rs?rev=815ee1f)",
  "js-sys",
  "leb128",
  "miracl_core_bls12381",

--- a/packages/ic-response-verification/Cargo.lock
+++ b/packages/ic-response-verification/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "ic-certification"
 version = "0.23.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=60f7a0d#60f7a0db21688ca423dee0bb150e142a03e925c6"
+source = "git+https://github.com/dfinity/agent-rs?rev=815ee1f#815ee1f523d498d8777a8941acf1a6042f959afc"
 dependencies = [
  "hex",
  "serde",

--- a/packages/ic-response-verification/Cargo.toml
+++ b/packages/ic-response-verification/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0.37"
 sha2 = "0.10.6"
 http = "0.2.8"
 # temporary git reference until a new release of ic-certification
-ic-certification = { git = "https://github.com/dfinity/agent-rs", default_features = false, rev = "60f7a0d" }
+ic-certification = { git = "https://github.com/dfinity/agent-rs", default_features = false, rev = "815ee1f" }
 miracl_core_bls12381 = { version = "4.2.2", default_features = false, features = ["std", "allow_alt_compress"] }
 flate2 = "1.0.24"
 leb128 = "0.2.5"
@@ -30,6 +30,6 @@ hex = "0.4.3"
 serde_cbor = "0.11.2"
 wasm-bindgen-test = "0.3"
 # temporary git reference until a new release of ic-certification
-ic-certification = { git = "https://github.com/dfinity/agent-rs", rev = "60f7a0d" }
+ic-certification = { git = "https://github.com/dfinity/agent-rs", rev = "815ee1f" }
 candid = "0.8.4"
 serde = "1.0.152"

--- a/packages/ic-response-verification/cargo-bazel-lock.json
+++ b/packages/ic-response-verification/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2f5cf75ef8d9f769d68df95a4f36be3c74192c1e4358a0417cd0bd69025b9d2c",
+  "checksum": "51d2d5284ab624f948f1afffb3f152a4f560750ac7bcb3c80d0891608364f959",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -1953,7 +1953,7 @@
         "Git": {
           "remote": "https://github.com/dfinity/agent-rs",
           "commitish": {
-            "Rev": "60f7a0d"
+            "Rev": "815ee1f"
           },
           "strip_prefix": "ic-certification"
         }

--- a/packages/ic-response-verification/src/test_utils.rs
+++ b/packages/ic-response-verification/src/test_utils.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 pub mod test_utils {
-    use ic_certification::hash_tree::{fork, label, leaf, pruned_from_hex};
+    use ic_certification::hash_tree::{fork, label, leaf, pruned_from_hex, Sha256Digest};
     use ic_certification::{Certificate, Delegation, HashTree};
 
     pub struct CreateTreeOptions<'a> {
@@ -121,6 +121,10 @@ pub mod test_utils {
 
     pub fn create_pruned(data: &str) -> HashTree {
         pruned_from_hex(data).unwrap()
+    }
+
+    pub fn sha256_from_hex(data: &str) -> Sha256Digest {
+        TryFrom::try_from(hex_decode(data)).unwrap()
     }
 
     pub fn hex_decode(data: &str) -> Vec<u8> {

--- a/packages/ic-response-verification/src/validation/v2_validation.rs
+++ b/packages/ic-response-verification/src/validation/v2_validation.rs
@@ -1,17 +1,32 @@
+use crate::types::Certification;
 use ic_certification::hash_tree::HashTreeNode;
-use ic_certification::{hash_tree::Sha256Digest, hash_tree::SubtreeLookupResult, HashTree, Label};
+use ic_certification::{hash_tree::Sha256Digest, HashTree, Label, SubtreeLookupResult};
 
-pub fn validate_expr_hash(
+pub fn validate_hashes(
     expr_hash: &Sha256Digest,
+    request_hash: &Option<Sha256Digest>,
+    response_hash: &Sha256Digest,
     expr_path: &Vec<String>,
     tree: &HashTree,
+    certification: &Certification,
 ) -> bool {
     let mut path = vec![Label::from("http_expr")];
     path.extend(expr_path.iter().map(Label::from));
+    path.push(expr_hash.into());
 
-    match tree.lookup_subtree(&path) {
-        SubtreeLookupResult::Found(HashTreeNode::Labeled(found_expr_hash, _)) => {
-            expr_hash.eq(found_expr_hash.as_bytes())
+    let SubtreeLookupResult::Found(expr_tree) = tree.lookup_subtree(&path) else {
+        return false;
+    };
+
+    let mut expr_tree_path: Vec<Label> = vec![];
+    if let (Some(_), Some(request_hash)) = (&certification.request_certification, request_hash) {
+        expr_tree_path.push(request_hash.into());
+    }
+    expr_tree_path.push(response_hash.into());
+
+    match expr_tree.lookup_subtree(&expr_tree_path) {
+        SubtreeLookupResult::Found(res_tree) => {
+            HashTreeNode::from(res_tree).eq(&HashTreeNode::Empty())
         }
         _ => false,
     }
@@ -20,18 +35,24 @@ pub fn validate_expr_hash(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::test_utils::hex_decode;
+    use crate::test_utils::test_utils::{hex_decode, sha256_from_hex};
+    use crate::types::{RequestCertification, ResponseCertification};
     use crate::{
         hash::hash,
         test_utils::test_utils::{create_pruned, remove_whitespace},
     };
     use ic_certification::hash_tree::{empty, fork, label};
 
+    const REQUEST_HASH: &str = "5fac69685533f0650991441a2b818e8ad5ab2fec51de8cfdbea1276135494815";
+    const RESPONSE_HASH: &str = "07b7c729f4083db0e266fef3f8f5acf1315135605bf38884c07ebb59fbf91ce8";
     const CEL_EXPRESSION: &str = r#"
         default_certification (
             ValidationArgs {
                 certification: Certification {
-                    no_request_certification: Empty {},
+                    request_certification: RequestCertification {
+                        certified_request_headers: ["host"],
+                        certified_query_parameters: []
+                    },
                     response_certification: ResponseCertification {
                         certified_response_headers: ResponseHeaderList {
                             headers: ["Accept-Encoding", "Cache-Control"]
@@ -43,8 +64,10 @@ mod tests {
     "#;
 
     #[test]
-    fn validate_expr_hash_that_exists() {
+    fn validate_hashes_that_exist() {
         let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
         let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
         let tree = fork(
             label(
@@ -53,14 +76,25 @@ mod tests {
                     "assets",
                     label(
                         "js",
-                        label("app.js", label("<$>", label(expr_hash, empty()))),
+                        label("app.js", label("<$>", label(expr_hash, fork(
+                            label(request_hash, label(response_hash, empty())),
+                            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+                        )))),
                     ),
                 ),
             ),
             create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
         );
+        let certification = create_certification();
 
-        let result = validate_expr_hash(&expr_hash, &expr_path, &tree);
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
 
         assert!(result);
     }
@@ -68,6 +102,8 @@ mod tests {
     #[test]
     fn validate_expr_hash_that_does_not_exist() {
         let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
         let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
         let tree = fork(
             label(
@@ -76,14 +112,31 @@ mod tests {
                     "assets",
                     label(
                         "css",
-                        label("app.css", label("<$>", label(expr_hash, empty()))),
+                        label(
+                            "app.css",
+                            label(
+                                "<$>",
+                                label(
+                                    expr_hash,
+                                    label(request_hash, label(response_hash, empty())),
+                                ),
+                            ),
+                        ),
                     ),
                 ),
             ),
             create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
         );
+        let certification = create_certification();
 
-        let result = validate_expr_hash(&expr_hash, &expr_path, &tree);
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
 
         assert!(!result);
     }
@@ -91,6 +144,8 @@ mod tests {
     #[test]
     fn validate_expr_hash_that_does_not_match() {
         let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
         let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
         let tree = fork(
             label(
@@ -105,18 +160,183 @@ mod tests {
                                 "<$>",
                                 label(
                                     hex_decode("c5dbe9d11756d4a7b05e5c0e246035dedcd1e4e71bd1e726c4011940d811496b"),
-                                    empty()
-                                )
-                            )
+                                    label(request_hash, label(response_hash, empty())),
+                                ),
+                            ),
                         ),
                     ),
                 ),
             ),
             create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
         );
+        let certification = create_certification();
 
-        let result = validate_expr_hash(&expr_hash, &expr_path, &tree);
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
 
         assert!(!result);
+    }
+
+    #[test]
+    fn validate_req_hash_that_does_not_exist() {
+        let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
+        let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
+        let tree = fork(
+            label(
+                "http_expr",
+                label(
+                    "assets",
+                    label(
+                        "js",
+                        label(
+                            "app.js",
+                            label("<$>", label(expr_hash, label(response_hash, empty()))),
+                        ),
+                    ),
+                ),
+            ),
+            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+        );
+        let certification = create_certification();
+
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn validate_req_hash_that_does_not_match() {
+        let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
+        let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
+        let tree = fork(
+            label(
+                "http_expr",
+                label(
+                    "assets",
+                    label(
+                        "js",
+                        label("app.js", label("<$>", label(expr_hash, fork(
+                            label(sha256_from_hex("236baceb3bbf1ad861a981807c4f7580344d8c7b25b7329be266c603ccc0f03e"), label(response_hash, empty())),
+                            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+                        )))),
+                    ),
+                ),
+            ),
+            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+        );
+        let certification = create_certification();
+
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn validate_res_hash_that_does_not_exist() {
+        let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
+        let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
+        let tree = fork(
+            label(
+                "http_expr",
+                label(
+                    "assets",
+                    label(
+                        "js",
+                        label("app.js", label("<$>", label(expr_hash, fork(
+                            label(request_hash, empty()),
+                            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+                        )))),
+                    ),
+                ),
+            ),
+            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+        );
+        let certification = create_certification();
+
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn validate_res_hash_that_does_not_match() {
+        let expr_hash = hash(remove_whitespace(CEL_EXPRESSION).as_bytes());
+        let request_hash = sha256_from_hex(REQUEST_HASH);
+        let response_hash = sha256_from_hex(RESPONSE_HASH);
+        let expr_path = vec!["assets".into(), "js".into(), "app.js".into(), "<$>".into()];
+        let tree = fork(
+            label(
+                "http_expr",
+                label(
+                    "assets",
+                    label(
+                        "js",
+                        label("app.js", label("<$>", label(expr_hash, fork(
+                            label(request_hash, label(sha256_from_hex("02456594f95f4e8f35f14850d23bc05aa065ecc17eb4aeaff3c1819edaee0816"), empty())),
+                            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+                        )))),
+                    ),
+                ),
+            ),
+            create_pruned("ea7fd1a6b0cac1fe118016ca3026e58d5ae67a6965478acb561edba542732e24"),
+        );
+        let certification = create_certification();
+
+        let result = validate_hashes(
+            &expr_hash,
+            &Some(request_hash),
+            &response_hash,
+            &expr_path,
+            &tree,
+            &certification,
+        );
+
+        assert!(!result);
+    }
+
+    fn create_certification() -> Certification {
+        Certification {
+            request_certification: Some(RequestCertification {
+                certified_request_headers: vec!["Host".into()],
+                certified_query_parameters: vec![],
+            }),
+            response_certification: ResponseCertification::CertifiedHeaders(vec![
+                "Accept-Encoding".into(),
+                "Cache-Control".into(),
+            ]),
+        }
     }
 }


### PR DESCRIPTION
This PR verifies the existence of the expected request & response hashes in the tree. I had originally planned to make this a separate function than the one that verifies the hash of the `expr_path`, but that didn't really make sense since the request and response hashes are nested below the `expr_path`, so now I've extended and renamed that function.