### PR TITLE
ci: use PAT to clone repo on merge to enable merging changelog updates

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.CHANGELOG_UPDATE_PAT }}
 
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Hopefully this works after merging, there's no way to test it before hand unfortunately.