### PR TITLE
docs: update readme to include external contributions exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Response Verification
 
+## Overview
+
+Response verification on the [Internet Computer](https://dfinity.org) is the process of verifying that a canister response from a replica has gone through consensus with other replicas hosting the same canister.
+
+This package encapsulates the protocol for such verification. It is used by [the Service Worker](https://github.com/dfinity/ic/tree/master/typescript/service-worker) and [ICX Proxy](https://github.com/dfinity/ic/tree/master/rs/boundary_node/icx_proxy) and may be used by other implementations of the [HTTP Gateway Protocol](https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway) in the future.
+
 ## Examples
 
 - [NodeJS](./examples/nodejs/README.md)
@@ -7,7 +13,9 @@
 - [Service Worker](./examples/service-worker/README.md)
 - [Web](./examples/web/README.md)
 
-## Developer Documentation
+## Contributing
+
+This repository is currently not accepting external contributions, but this will change in the near future once the code base stabilizes.
 
 ### Setup
 


### PR DESCRIPTION
IT requested that we make it clear that external contributions are removed: https://dfinity.slack.com/archives/CGJND92DA/p1675771354828049?thread_ts=1675761758.162389&cid=CGJND92DA

The other option was to remove the "contribution" documentation, but I'd rather keep it.