### PR TITLE
ci: remove unnecessary PAT

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.CHANGELOG_UPDATE_PAT }}
 
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This token isn't working and not necessary anymore after switching to the PR approach for updating changelog