### PR TITLE
fix: apply release profile to wasm crate properly and fix small clippy issues

### DIFF
--- a/packages/ic-response-verification-test-utils/src/expr_tree.rs
+++ b/packages/ic-response-verification-test-utils/src/expr_tree.rs
@@ -56,7 +56,7 @@ impl ExprTree {
     }
 
     pub fn insert(&mut self, path: &[ExprTreeKey]) {
-        self.tree.insert(&path, b"".to_vec())
+        self.tree.insert(path, b"".to_vec())
     }
 
     pub fn serialize_to_cbor(&self, path: &[ExprTreeKey]) -> Vec<u8> {
@@ -81,7 +81,7 @@ pub fn create_expr_tree_path(
     res_hash: Option<&Hash>,
 ) -> Vec<ExprTreeKey> {
     let mut path: Vec<ExprTreeKey> = vec![];
-    path.extend(expr_path.into_iter().map(|e| ExprTreeKey::from(*e)));
+    path.extend(expr_path.iter().map(|e| ExprTreeKey::from(*e)));
 
     path.push(expr_hash.as_slice().into());
     if let Some(req_hash) = req_hash {

--- a/packages/ic-response-verification-wasm/Cargo.toml
+++ b/packages/ic-response-verification-wasm/Cargo.toml
@@ -22,6 +22,11 @@ crate-type = ["cdylib", "rlib"]
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
+[profile.release]
+lto = true
+opt-level = 'z'
+codegen-units = 1
+
 [dependencies]
 ic-response-verification = { path = "../ic-response-verification", features = ["js"] }
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
After moving the wasm-bindgen stuff to a separate crate that crate was removed from the root "workspace" to prevent issues with differing targets, since this crate is built against the wasm target. This broke the release profile for that crate since the release profile is specified in the root workspace that it's no longer a part of, this made the file size more than 700kb :D