### PR TITLE
test: add unit tests to prove multiple expressions per path are allowed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
       - name: Release @dfinity/response-verification NPM package
-        run: npm publish ./pkg
+        run: npm publish ./pkg --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
add unit test to prove that an expr path and tree that does not begin with http_expr will not pass certification, publish npm package as a public package