### PR TITLE
ci: fix artifacts patterns for the create release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: >
-            target/package/ic-response-verification-${{ github.ref_name }}.crate
+            target/package/ic-response-verification-${{ github.ref_name }}.crate,
             dfinity-response-verification-${{ github.ref_name }}.tgz
           bodyFile: "RELEASE_NOTES.md"
           tag: "${{ github.ref_name }}"


### PR DESCRIPTION
According to the docs: https://github.com/ncipollo/release-action

> An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)

The last release still didn't include the artifacts so hopefully this fixes it.