### PR TITLE
Nathan/sad path integration tests part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,58 +779,93 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.25"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn 2.0.12",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1355,6 +1390,7 @@ dependencies = [
  "log",
  "miracl_core_bls12381",
  "nom",
+ "rstest",
  "serde",
  "serde_cbor",
  "sha2 0.10.6",
@@ -2259,6 +2295,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.105",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust"
 version = "0.1.0"
 dependencies = [
@@ -2267,6 +2329,15 @@ dependencies = [
  "ic-response-verification",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2436,7 +2507,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2681,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2739,7 +2810,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.12",
 ]
 
 [[package]]

--- a/packages/ic-response-verification-test-utils/src/expr_tree.rs
+++ b/packages/ic-response-verification-test-utils/src/expr_tree.rs
@@ -59,9 +59,15 @@ impl ExprTree {
         self.tree.insert(path, b"".to_vec())
     }
 
-    pub fn serialize_to_cbor(&self, path: &[ExprTreeKey]) -> Vec<u8> {
+    pub fn witness_and_serialize_to_cbor(&self, path: &[ExprTreeKey]) -> Vec<u8> {
         let tree = self.tree.witness(path);
         let labeled_tree = labeled(LABEL_EXPR, tree);
+
+        serialize_to_cbor::<HashTree>(&labeled_tree)
+    }
+
+    pub fn serialize_to_cbor(&self) -> Vec<u8> {
+        let labeled_tree = labeled(LABEL_EXPR, self.tree.as_hash_tree());
 
         serialize_to_cbor::<HashTree>(&labeled_tree)
     }

--- a/packages/ic-response-verification/Cargo.toml
+++ b/packages/ic-response-verification/Cargo.toml
@@ -46,3 +46,4 @@ ic-response-verification-test-utils = { path = "../ic-response-verification-test
 ic-crypto-tree-hash = { git = "https://github.com/dfinity/ic", rev = "a533346f63f4091eb64692891de0d5b2ffd5b22a" }
 ic-types = { git = "https://github.com/dfinity/ic", rev = "a533346f63f4091eb64692891de0d5b2ffd5b22a" }
 ic-certified-map = "0.3.2"
+rstest = "0.17.0"

--- a/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
@@ -5,7 +5,7 @@ mod tests {
     use ic_response_verification::types::{CertifiedResponse, Request, Response};
     use ic_response_verification::verify_request_response_pair;
     use ic_response_verification_test_utils::{
-        create_canister_id, create_v2_fixture, get_current_timestamp, remove_whitespace, V2Fixture,
+        create_v2_fixture, get_current_timestamp, remove_whitespace, V2Fixture,
     };
 
     const MAX_CERT_TIME_OFFSET_NS: u128 = 300_000_000_000;
@@ -16,7 +16,6 @@ mod tests {
         let path = "/";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
         let cel_expr = remove_whitespace(
             r#"
@@ -45,14 +44,8 @@ mod tests {
         let V2Fixture {
             root_key,
             certificate_header,
-        } = create_v2_fixture(
-            &cel_expr,
-            &expr_path,
-            &canister_id,
-            &current_time,
-            None,
-            None,
-        );
+            canister_id,
+        } = create_v2_fixture(&cel_expr, &expr_path, &current_time, None, None);
 
         response
             .headers
@@ -79,7 +72,6 @@ mod tests {
         let path = "/";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
         let cel_expr = remove_whitespace(
             r#"
@@ -119,10 +111,10 @@ mod tests {
         let V2Fixture {
             root_key,
             certificate_header,
+            canister_id,
         } = create_v2_fixture(
             &cel_expr,
             &expr_path,
-            &canister_id,
             &current_time,
             None,
             Some(&response_hash),
@@ -159,7 +151,6 @@ mod tests {
         let path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
         let cel_expr = remove_whitespace(
             r#"
@@ -207,10 +198,10 @@ mod tests {
         let V2Fixture {
             root_key,
             certificate_header,
+            canister_id,
         } = create_v2_fixture(
             &cel_expr,
             &expr_path,
-            &canister_id,
             &current_time,
             Some(&request_hash),
             Some(&response_hash),
@@ -247,7 +238,6 @@ mod tests {
         let path = "/";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
         let cel_expr = remove_whitespace(
             r#"
@@ -290,10 +280,10 @@ mod tests {
         let V2Fixture {
             root_key,
             certificate_header,
+            canister_id,
         } = create_v2_fixture(
             &cel_expr,
             &expr_path,
-            &canister_id,
             &current_time,
             None,
             Some(&response_hash),

--- a/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
@@ -1,5 +1,10 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
+    use crate::fixtures::{
+        self, expired_certificate, full_certification_cel, future_certificate,
+        invalid_root_key_certificate, skip_certification_cel, wrong_canister_certificate,
+        MAX_CERT_TIME_OFFSET_NS, MIN_REQUESTED_VERIFICATION_VERSION,
+    };
     use ic_response_verification::{
         cel::cel_to_certification,
         hash::{request_hash, response_hash},
@@ -7,40 +12,18 @@ mod tests {
         verify_request_response_pair,
     };
     use ic_response_verification_test_utils::{
-        create_canister_id, create_v2_certificate_fixture, create_v2_fixture, create_v2_header,
-        create_v2_tree_fixture, get_current_timestamp, hash_from_hex, remove_whitespace,
+        create_expr_tree_path, create_v2_certificate_fixture, create_v2_fixture, create_v2_header,
+        create_v2_tree_fixture, get_current_timestamp, hash, hash_from_hex, ExprTree,
         V2CertificateFixture, V2Fixture, V2TreeFixture,
     };
+    use rstest::*;
 
-    const MAX_CERT_TIME_OFFSET_NS: u128 = 300_000_000_000;
-    const MIN_REQUESTED_VERIFICATION_VERSION: u8 = 2;
-
-    #[test]
-    fn request_hash_mismatch_fails_verification() {
+    #[rstest]
+    fn request_hash_mismatch_fails_verification(#[from(full_certification_cel)] cel_expr: String) {
         let path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
-        let cel_expr = remove_whitespace(
-            r#"
-            default_certification (
-                ValidationArgs {
-                    certification: Certification {
-                        request_certification: RequestCertification {
-                            certified_request_headers: ["Cache-Control"],
-                            certified_query_parameters: ["q"]
-                        },
-                        response_certification: ResponseCertification {
-                            certified_response_headers: ResponseHeaderList {
-                                headers: ["Cache-Control"]
-                            }
-                        }
-                    }
-                }
-            )
-        "#,
-        );
         let certification = cel_to_certification(&cel_expr).unwrap().unwrap();
         let response_certification = certification.response_certification;
 
@@ -68,10 +51,10 @@ mod tests {
         let V2Fixture {
             root_key,
             certificate_header,
+            canister_id,
         } = create_v2_fixture(
             &cel_expr,
             &expr_path,
-            &canister_id,
             &current_time,
             Some(&request_hash),
             Some(&response_hash),
@@ -86,42 +69,25 @@ mod tests {
             response,
             canister_id.as_ref(),
             current_time,
-            MAX_CERT_TIME_OFFSET_NS,
+            fixtures::MAX_CERT_TIME_OFFSET_NS,
             &root_key,
-            MIN_REQUESTED_VERIFICATION_VERSION,
+            fixtures::MIN_REQUESTED_VERIFICATION_VERSION,
         )
         .unwrap();
 
         assert!(!result.passed);
         assert_eq!(result.response, None);
+        assert_eq!(result.verification_version, 2);
     }
 
-    #[test]
-    pub fn response_hash_mismatch_fails_verification() {
+    #[rstest]
+    pub fn response_hash_mismatch_fails_verification(
+        #[from(full_certification_cel)] cel_expr: String,
+    ) {
         let path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
-        let cel_expr = remove_whitespace(
-            r#"
-            default_certification (
-                ValidationArgs {
-                    certification: Certification {
-                        request_certification: RequestCertification {
-                            certified_request_headers: ["Cache-Control"],
-                            certified_query_parameters: ["q"]
-                        },
-                        response_certification: ResponseCertification {
-                            certified_response_headers: ResponseHeaderList {
-                                headers: ["Cache-Control"]
-                            }
-                        }
-                    }
-                }
-            )
-        "#,
-        );
         let certification = cel_to_certification(&cel_expr).unwrap().unwrap();
         let request_certification = certification.request_certification.unwrap();
 
@@ -149,10 +115,10 @@ mod tests {
         let V2Fixture {
             root_key,
             certificate_header,
+            canister_id,
         } = create_v2_fixture(
             &cel_expr,
             &expr_path,
-            &canister_id,
             &current_time,
             Some(&request_hash),
             Some(&response_hash),
@@ -175,43 +141,18 @@ mod tests {
 
         assert!(!result.passed);
         assert_eq!(result.response, None);
+        assert_eq!(result.verification_version, 2);
     }
 
-    #[test]
-    fn cel_expr_hash_fails_verification() {
+    #[rstest]
+    fn cel_expr_hash_fails_verification(
+        #[from(skip_certification_cel)] wrong_cel_expr: String,
+        #[from(full_certification_cel)] cel_expr: String,
+    ) {
         let path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let canister_id = create_canister_id("rdmx6-jaaaa-aaaaa-aaadq-cai");
         let expr_path = ["", "<$>"];
-        let wrong_cel_expr = remove_whitespace(
-            r#"
-            default_certification (
-                ValidationArgs {
-                    no_certification: Empty { }
-                }
-            )
-        "#,
-        );
-        let cel_expr = remove_whitespace(
-            r#"
-            default_certification (
-                ValidationArgs {
-                    certification: Certification {
-                        request_certification: RequestCertification {
-                            certified_request_headers: ["Cache-Control"],
-                            certified_query_parameters: ["q"]
-                        },
-                        response_certification: ResponseCertification {
-                            certified_response_headers: ResponseHeaderList {
-                                headers: ["Cache-Control"]
-                            }
-                        }
-                    }
-                }
-            )
-        "#,
-        );
         let certification = cel_to_certification(&cel_expr).unwrap().unwrap();
         let request_certification = certification.request_certification.unwrap();
         let response_certification = certification.response_certification;
@@ -248,7 +189,8 @@ mod tests {
         let V2CertificateFixture {
             root_key,
             certificate_cbor,
-        } = create_v2_certificate_fixture(&canister_id, &certified_data, &current_time);
+            canister_id,
+        } = create_v2_certificate_fixture(&certified_data, &current_time);
         let certificate_header = create_v2_header(&expr_path, &certificate_cbor, &tree_cbor);
 
         response
@@ -268,5 +210,255 @@ mod tests {
 
         assert!(!result.passed);
         assert_eq!(result.response, None);
+        assert_eq!(result.verification_version, 2);
+    }
+
+    #[rstest]
+    #[case::does_not_exist_in_tree(&["assets", "css", "<*>"])]
+    #[case::more_specific_path_exists_in_tree(&["assets", "<*>"])]
+    #[case::does_not_match_request_url(&["assets", "js", "dashboard.js", "<$>"])]
+    fn invalid_expr_path_fails_verification(
+        #[from(skip_certification_cel)] cel_expr: String,
+        #[case] expr_path: &[&str],
+    ) {
+        let current_time = get_current_timestamp();
+
+        let request = Request {
+            url: "/assets/js/app.js".to_string(),
+            method: "GET".to_string(),
+            headers: vec![],
+        };
+        let mut response = Response {
+            status_code: 200,
+            body: b"Hello World!".to_vec(),
+            headers: vec![("IC-CertificateExpression".to_string(), cel_expr.clone())],
+        };
+
+        let cel_expr_hash = hash(cel_expr);
+        let mut expr_tree = ExprTree::new();
+
+        expr_tree.insert(&create_expr_tree_path(
+            &["assets", "<*>"],
+            &cel_expr_hash,
+            None,
+            None,
+        ));
+        expr_tree.insert(&create_expr_tree_path(
+            &["assets", "js", "<*>"],
+            &cel_expr_hash,
+            None,
+            None,
+        ));
+        expr_tree.insert(&create_expr_tree_path(
+            &["assets", "js", "dashboard.js", "<$>"],
+            &cel_expr_hash,
+            None,
+            None,
+        ));
+
+        let V2CertificateFixture {
+            root_key,
+            certificate_cbor,
+            canister_id,
+        } = create_v2_certificate_fixture(&expr_tree.get_certified_data(), &current_time);
+        let certificate_header = create_v2_header(
+            &expr_path,
+            &certificate_cbor,
+            &expr_tree.serialize_to_cbor(),
+        );
+
+        response
+            .headers
+            .push(("IC-Certificate".to_string(), certificate_header));
+
+        let result = verify_request_response_pair(
+            request,
+            response,
+            canister_id.as_ref(),
+            current_time,
+            MAX_CERT_TIME_OFFSET_NS,
+            &root_key,
+            MIN_REQUESTED_VERIFICATION_VERSION,
+        )
+        .unwrap();
+
+        assert!(!result.passed);
+        assert_eq!(result.response, None);
+        assert_eq!(result.verification_version, 2);
+    }
+
+    #[rstest]
+    #[case::invalid_root_key_certificate(invalid_root_key_certificate())]
+    #[case::expired_certificate(expired_certificate())]
+    #[case::future_certificate(future_certificate())]
+    #[case::wrong_canister_certificate(wrong_canister_certificate())]
+    fn invalid_certificate_fails_verification(#[case] fixture: (V2Fixture, u128, String)) {
+        let (
+            V2Fixture {
+                root_key,
+                certificate_header,
+                canister_id,
+            },
+            current_time,
+            cel_expr,
+        ) = fixture;
+
+        let path = "/";
+        let body = "Hello World!";
+
+        let request = Request {
+            url: path.into(),
+            method: "GET".into(),
+            headers: vec![],
+        };
+        let mut response = Response {
+            status_code: 200,
+            body: body.as_bytes().to_vec(),
+            headers: vec![
+                ("IC-CertificateExpression".into(), cel_expr.clone()),
+                ("Cache-Control".into(), "max-age=604800".into()),
+            ],
+        };
+
+        response
+            .headers
+            .push(("IC-Certificate".into(), certificate_header));
+
+        let result = verify_request_response_pair(
+            request,
+            response,
+            canister_id.as_ref(),
+            current_time,
+            MAX_CERT_TIME_OFFSET_NS,
+            &root_key,
+            MIN_REQUESTED_VERIFICATION_VERSION,
+        );
+
+        println!("Result: {:#?}", result);
+
+        assert!(result.is_err());
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod fixtures {
+    use ic_response_verification_test_utils::{
+        create_v2_fixture, get_current_timestamp, get_timestamp, remove_whitespace, V2Fixture,
+    };
+    use ic_types::CanisterId;
+    use rstest::*;
+    use std::{
+        ops::{Add, Sub},
+        time::{Duration, SystemTime},
+    };
+
+    pub const MAX_CERT_TIME_OFFSET_NS: u128 = 300_000_000_000;
+    pub const MIN_REQUESTED_VERIFICATION_VERSION: u8 = 2;
+
+    #[fixture]
+    pub fn full_certification_cel() -> String {
+        remove_whitespace(
+            r#"
+                default_certification (
+                    ValidationArgs {
+                        certification: Certification {
+                            request_certification: RequestCertification {
+                                certified_request_headers: ["Cache-Control"],
+                                certified_query_parameters: ["q"]
+                            },
+                            response_certification: ResponseCertification {
+                                certified_response_headers: ResponseHeaderList {
+                                    headers: ["Cache-Control"]
+                                }
+                            }
+                        }
+                    }
+                )
+            "#,
+        )
+    }
+
+    #[fixture]
+    pub fn skip_certification_cel() -> String {
+        remove_whitespace(
+            r#"
+                default_certification (
+                    ValidationArgs {
+                        no_certification: Empty { }
+                    }
+                )
+            "#,
+        )
+    }
+
+    pub fn invalid_root_key_certificate() -> (V2Fixture, u128, String) {
+        let cel_expr = skip_certification_cel();
+        let expr_path = ["", "<$>"];
+        let current_time = get_current_timestamp();
+
+        let root_key = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00\x81\x4c\x0e\x6e\xc7\x1f\xab\x58\x3b\x08\xbd\x81\x37\x3c\x25\x5c\x3c\x37\x1b\x2e\x84\x86\x3c\x98\xa4\xf1\xe0\x8b\x74\x23\x5d\x14\xfb\x5d\x9c\x0c\xd5\x46\xd9\x68\x5f\x91\x3a\x0c\x0b\x2c\xc5\x34\x15\x83\xbf\x4b\x43\x92\xe4\x67\xdb\x96\xd6\x5b\x9b\xb4\xcb\x71\x71\x12\xf8\x47\x2e\x0d\x5a\x4d\x14\x50\x5f\xfd\x74\x84\xb0\x12\x91\x09\x1c\x5f\x87\xb9\x88\x83\x46\x3f\x98\x09\x1a\x0b\xaa\xae";
+
+        let v2_fixture = create_v2_fixture(&cel_expr, &expr_path, &current_time, None, None);
+
+        (
+            V2Fixture {
+                certificate_header: v2_fixture.certificate_header,
+                canister_id: v2_fixture.canister_id,
+                root_key: root_key.to_vec(),
+            },
+            current_time,
+            cel_expr,
+        )
+    }
+
+    pub fn expired_certificate() -> (V2Fixture, u128, String) {
+        let cel_expr = skip_certification_cel();
+        let expr_path = ["", "<$>"];
+        let current_time = get_current_timestamp();
+
+        let max_cert_time_offset_s: u64 = (MAX_CERT_TIME_OFFSET_NS / 1_000_000_000)
+            .try_into()
+            .unwrap();
+        let past_time =
+            get_timestamp(SystemTime::now().sub(Duration::new(max_cert_time_offset_s + 1, 0)));
+
+        let v2_fixture = create_v2_fixture(&cel_expr, &expr_path, &past_time, None, None);
+
+        (v2_fixture, current_time, cel_expr)
+    }
+
+    pub fn future_certificate() -> (V2Fixture, u128, String) {
+        let cel_expr = skip_certification_cel();
+        let expr_path = ["", "<$>"];
+        let current_time = get_current_timestamp();
+
+        let max_cert_time_offset_s: u64 = (MAX_CERT_TIME_OFFSET_NS / 1_000_000_000)
+            .try_into()
+            .unwrap();
+        let future_time =
+            get_timestamp(SystemTime::now().add(Duration::new(max_cert_time_offset_s + 1, 0)));
+
+        let v2_fixture = create_v2_fixture(&cel_expr, &expr_path, &future_time, None, None);
+
+        (v2_fixture, current_time, cel_expr)
+    }
+
+    pub fn wrong_canister_certificate() -> (V2Fixture, u128, String) {
+        let cel_expr = skip_certification_cel();
+        let expr_path = ["", "<$>"];
+        let other_canister_id = CanisterId::from_u64(15);
+        let current_time = get_current_timestamp();
+
+        let v2_fixture = create_v2_fixture(&cel_expr, &expr_path, &current_time, None, None);
+
+        (
+            V2Fixture {
+                root_key: v2_fixture.root_key,
+                certificate_header: v2_fixture.certificate_header,
+                canister_id: other_canister_id,
+            },
+            current_time,
+            cel_expr,
+        )
     }
 }


### PR DESCRIPTION
I've added more sad path tests here but also added this `rstest` library: https://github.com/la10736/rstest
It supports fixture injection and parameterized tests. I've refactored _some_ tests, but not all, to keep the PR size smaller.
I'll continue to refactor more tests and follow up with more PRs.