### PR TITLE
ci: correct the wasm-bindgen-console-logger version

### DIFF
--- a/packages/ic-response-verification-wasm/Cargo.lock
+++ b/packages/ic-response-verification-wasm/Cargo.lock
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "ic-response-verification"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "ic-response-verification-test-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.0",
  "getrandom",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ic-response-verification-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.0",
  "console_error_panic_hook",

--- a/packages/ic-response-verification-wasm/Cargo.toml
+++ b/packages/ic-response-verification-wasm/Cargo.toml
@@ -28,7 +28,7 @@ js-sys = "0.3"
 wasm-bindgen = "0.2.83"
 wee_alloc = "0.4.5"
 log = { version = "0.4.17", optional = true }
-wasm-bindgen-console-logger = { version = "0.2.0", optional = true }
+wasm-bindgen-console-logger = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 base64 = "0.21.0"


### PR DESCRIPTION
`wasm-bindgen-console-logger` v0.2.0 seems to have been pulled from crates.io.
https://docs.rs/wasm-bindgen-console-logger/latest/wasm_bindgen_console_logger/