### PR TITLE
feat(hash): add support for byte values

### DIFF
--- a/packages/ic-representation-independent-hash/src/lib.rs
+++ b/packages/ic-representation-independent-hash/src/lib.rs
@@ -2,6 +2,14 @@
 //! [Representation Independent Hashes](https://internetcomputer.org/docs/current/references/ic-interface-spec/#hash-of-map)
 //! of [crate::Request] and [crate::Response] objects.
 
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links
+)]
+
+/// Type alias for a SHA-256 hash.
 pub type Sha256Digest = [u8; 32];
 
 mod representation_independent_hash;
@@ -9,6 +17,7 @@ pub use representation_independent_hash::*;
 
 use sha2::{Digest, Sha256};
 
+/// Calculates the SHA-256 hash of the given slice.
 pub fn hash(data: &[u8]) -> Sha256Digest {
     let mut hasher = Sha256::new();
     hasher.update(data);

--- a/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
+++ b/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
@@ -101,9 +101,8 @@ mod tests {
 
     #[test]
     fn hash_bytes() {
-        let map: Vec<(String, Value)> = vec![
-            ("bytes".into(), Value::Bytes(vec![0x01, 0x02, 0x03, 0x04])),
-        ];
+        let map: Vec<(String, Value)> =
+            vec![("bytes".into(), Value::Bytes(vec![0x01, 0x02, 0x03, 0x04]))];
         let expected_hash =
             hex::decode("546729666d96a712bd94f902a0388e33f9a19a335c35bc3d95b0221a4a574455")
                 .unwrap();

--- a/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
+++ b/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
@@ -8,6 +8,7 @@ pub enum Value {
     String(String),
     /// A number to be hashed.
     Number(u64),
+    /// Bytes to be hashed.
     Bytes(Vec<u8>),
 }
 


### PR DESCRIPTION
Support `Vec<u8>` values for representation independent hash