### PR TITLE
(refactor: TT-79) Standardize verification errors as reasons

### DIFF
--- a/packages/ic-response-verification/src/error.rs
+++ b/packages/ic-response-verification/src/error.rs
@@ -332,9 +332,7 @@ impl From<ResponseVerificationError> for ResponseVerificationJsError {
             ResponseVerificationError::ParseIntError(_) => {
                 ResponseVerificationJsErrorCode::ParseIntError
             }
-            ResponseVerificationError::InvalidTree => {
-                ResponseVerificationJsErrorCode::InvalidTree
-            }
+            ResponseVerificationError::InvalidTree => ResponseVerificationJsErrorCode::InvalidTree,
             ResponseVerificationError::InvalidExpressionPath => {
                 ResponseVerificationJsErrorCode::InvalidExpressionPath
             }
@@ -347,9 +345,7 @@ impl From<ResponseVerificationError> for ResponseVerificationJsError {
             ResponseVerificationError::MissingCertificate => {
                 ResponseVerificationJsErrorCode::MissingCertificate
             }
-            ResponseVerificationError::MissingTree => {
-                ResponseVerificationJsErrorCode::MissingTree
-            }
+            ResponseVerificationError::MissingTree => ResponseVerificationJsErrorCode::MissingTree,
             ResponseVerificationError::MissingCertification => {
                 ResponseVerificationJsErrorCode::MissingCertification
             }

--- a/packages/ic-response-verification/src/error.rs
+++ b/packages/ic-response-verification/src/error.rs
@@ -230,6 +230,20 @@ pub enum ResponseVerificationJsErrorCode {
     Base64DecodingError,
     /// Error parsing int
     ParseIntError,
+    /// The tree has different root hash from the expected value in the certified variables
+    InvalidTree,
+    /// The CEL expression path is invalid
+    InvalidExpressionPath,
+    /// The response body was a mismatch from the expected values in the tree
+    InvalidResponseBody,
+    /// The response hashes were a mismatch from the expected values in the tree
+    InvalidResponseHashes,
+    /// The certificate was missing from the response headers
+    MissingCertificate,
+    /// The tree was missing from the response headers
+    MissingTree,
+    /// The certification values could not be found in the response headers
+    MissingCertification,
 }
 
 /// JS Representation of the ResponseVerificationError
@@ -317,6 +331,27 @@ impl From<ResponseVerificationError> for ResponseVerificationJsError {
             }
             ResponseVerificationError::ParseIntError(_) => {
                 ResponseVerificationJsErrorCode::ParseIntError
+            }
+            ResponseVerificationError::InvalidTree => {
+                ResponseVerificationJsErrorCode::InvalidTree
+            }
+            ResponseVerificationError::InvalidExpressionPath => {
+                ResponseVerificationJsErrorCode::InvalidExpressionPath
+            }
+            ResponseVerificationError::InvalidResponseBody => {
+                ResponseVerificationJsErrorCode::InvalidResponseBody
+            }
+            ResponseVerificationError::InvalidResponseHashes => {
+                ResponseVerificationJsErrorCode::InvalidResponseHashes
+            }
+            ResponseVerificationError::MissingCertificate => {
+                ResponseVerificationJsErrorCode::MissingCertificate
+            }
+            ResponseVerificationError::MissingTree => {
+                ResponseVerificationJsErrorCode::MissingTree
+            }
+            ResponseVerificationError::MissingCertification => {
+                ResponseVerificationJsErrorCode::MissingCertification
             }
         };
         let message = error.to_string();

--- a/packages/ic-response-verification/src/error.rs
+++ b/packages/ic-response-verification/src/error.rs
@@ -799,4 +799,130 @@ mod tests {
             }
         )
     }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_tree_error() {
+        let error = ResponseVerificationError::InvalidTree;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::InvalidTree,
+                message: format!(r#"Invalid tree root hash"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_expression_path_error() {
+        let error = ResponseVerificationError::InvalidExpressionPath;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::InvalidExpressionPath,
+                message: format!(r#"Invalid expression path"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_response_body_error() {
+        let error = ResponseVerificationError::InvalidResponseBody;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::InvalidResponseBody,
+                message: format!(r#"Invalid response body"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_response_hashes_error() {
+        let error = ResponseVerificationError::InvalidResponseHashes;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::InvalidResponseHashes,
+                message: format!(r#"Invalid response hashes"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_missing_certificate_error() {
+        let error = ResponseVerificationError::MissingCertificate;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::MissingCertificate,
+                message: format!(r#"Certificate not found"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_missing_tree_error() {
+        let error = ResponseVerificationError::MissingTree;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::MissingTree,
+                message: format!(r#"Tree not found"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_missing_certificate_expr_path_error() {
+        let error = ResponseVerificationError::MissingCertificateExpressionPath;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::MissingCertificateExpressionPath,
+                message: format!(r#"Certificate expression path not found"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_missing_certificate_expr_error() {
+        let error = ResponseVerificationError::MissingCertificateExpression;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::MissingCertificateExpression,
+                message: format!(r#"Certificate expression not found"#),
+            }
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn error_into_invalid_missing_certification_error() {
+        let error = ResponseVerificationError::MissingCertification;
+        let result = ResponseVerificationJsError::from(error);
+
+        assert_eq!(
+            result,
+            ResponseVerificationJsError {
+                code: ResponseVerificationJsErrorCode::MissingCertification,
+                message: format!(r#"Certification values not found"#),
+            }
+        )
+    }
 }

--- a/packages/ic-response-verification/src/error.rs
+++ b/packages/ic-response-verification/src/error.rs
@@ -147,6 +147,34 @@ pub enum ResponseVerificationError {
     /// Error parsing int
     #[error("Error parsing int")]
     ParseIntError(#[from] std::num::ParseIntError),
+
+    /// The tree has different root hash from the expected value in the certified variables
+    #[error("Invalid tree root hash")]
+    InvalidTree,
+
+    /// The CEL expression path is invalid
+    #[error("Invalid expression path")]
+    InvalidExpressionPath,
+
+    /// The response body was a mismatch from the expected values in the tree
+    #[error("Invalid response body")]
+    InvalidResponseBody,
+
+    /// The response hashes were a mismatch from the expected values in the tree
+    #[error("Invalid response hashes")]
+    InvalidResponseHashes,
+
+    /// The certificate was missing from the response headers
+    #[error("Certificate not found")]
+    MissingCertificate,
+
+    /// The tree was missing from the response headers
+    #[error("Tree not found")]
+    MissingTree,
+
+    /// The certification values could not be found in the response headers
+    #[error("Certification values not found")]
+    MissingCertification,
 }
 
 /// JS Representation of the ResponseVerificationError code

--- a/packages/ic-response-verification/src/error.rs
+++ b/packages/ic-response-verification/src/error.rs
@@ -164,13 +164,21 @@ pub enum ResponseVerificationError {
     #[error("Invalid response hashes")]
     InvalidResponseHashes,
 
-    /// The certificate was missing from the response headers
+    /// The certificate was missing from the certification header
     #[error("Certificate not found")]
     MissingCertificate,
 
-    /// The tree was missing from the response headers
+    /// The tree was missing from the certification header
     #[error("Tree not found")]
     MissingTree,
+
+    /// The certificate expression path was missing from the certification header
+    #[error("Certificate expression path not found")]
+    MissingCertificateExpressionPath,
+
+    /// The certificate expression was missing from the response headers
+    #[error("Certificate expression not found")]
+    MissingCertificateExpression,
 
     /// The certification values could not be found in the response headers
     #[error("Certification values not found")]
@@ -238,10 +246,14 @@ pub enum ResponseVerificationJsErrorCode {
     InvalidResponseBody,
     /// The response hashes were a mismatch from the expected values in the tree
     InvalidResponseHashes,
-    /// The certificate was missing from the response headers
+    /// The certificate was missing from the certification header
     MissingCertificate,
-    /// The tree was missing from the response headers
+    /// The tree was missing from the certification header
     MissingTree,
+    /// The certificate expression path was missing from the certification header
+    MissingCertificateExpressionPath,
+    /// The certificate expression was missing from the response headers
+    MissingCertificateExpression,
     /// The certification values could not be found in the response headers
     MissingCertification,
 }
@@ -346,6 +358,12 @@ impl From<ResponseVerificationError> for ResponseVerificationJsError {
                 ResponseVerificationJsErrorCode::MissingCertificate
             }
             ResponseVerificationError::MissingTree => ResponseVerificationJsErrorCode::MissingTree,
+            ResponseVerificationError::MissingCertificateExpressionPath => {
+                ResponseVerificationJsErrorCode::MissingCertificateExpressionPath
+            }
+            ResponseVerificationError::MissingCertificateExpression => {
+                ResponseVerificationJsErrorCode::MissingCertificateExpression
+            }
             ResponseVerificationError::MissingCertification => {
                 ResponseVerificationJsErrorCode::MissingCertification
             }

--- a/packages/ic-response-verification/src/types/verification_result.rs
+++ b/packages/ic-response-verification/src/types/verification_result.rs
@@ -4,7 +4,7 @@ use crate::{types::VerifiedResponse, ResponseVerificationError};
 use wasm_bindgen::prelude::*;
 
 #[cfg(all(target_arch = "wasm32", feature = "js"))]
-use crate::{ResponseVerificationJsError};
+use crate::ResponseVerificationJsError;
 
 #[cfg(all(target_arch = "wasm32", feature = "js"))]
 #[wasm_bindgen(typescript_custom_section)]
@@ -58,7 +58,6 @@ impl From<VerificationResult> for JsValue {
                 let verification_version_entry =
                     Array::of2(&JsValue::from("verificationVersion"), &verification_version);
 
-
                 let reason = JsValue::from(ResponseVerificationJsError::from(reason));
                 let reason_entry = Array::of2(&JsValue::from("reason"), &reason.into());
 
@@ -98,8 +97,8 @@ impl From<VerificationResult> for JsValue {
 
 #[cfg(all(target_arch = "wasm32", feature = "js", test))]
 mod tests {
-    use crate::ResponseVerificationError;
     use crate::types::{VerificationResult, VerifiedResponse};
+    use crate::ResponseVerificationError;
     use js_sys::JSON;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/packages/ic-response-verification/src/types/verification_result.rs
+++ b/packages/ic-response-verification/src/types/verification_result.rs
@@ -1,4 +1,4 @@
-use crate::types::VerifiedResponse;
+use crate::{types::VerifiedResponse, ResponseVerificationError};
 
 #[cfg(all(target_arch = "wasm32", feature = "js"))]
 use wasm_bindgen::prelude::*;
@@ -32,6 +32,8 @@ pub enum VerificationResult {
     Failed {
         /// The version of verification that was used to verify the response
         verification_version: u16,
+        /// The reason why the verification of the response has failed
+        reason: ResponseVerificationError,
     },
 }
 

--- a/packages/ic-response-verification/src/types/verification_result.rs
+++ b/packages/ic-response-verification/src/types/verification_result.rs
@@ -13,6 +13,7 @@ type VerificationResult = {
 } | {
   passed: false;
   verificationVersion: number;
+  reason: ResponseVerificationError;
 }
 "#;
 
@@ -45,6 +46,7 @@ impl From<VerificationResult> for JsValue {
         let result = match verification_result {
             VerificationResult::Failed {
                 verification_version,
+                reason,
             } => {
                 let passed = Boolean::from(false);
                 let passed_entry = Array::of2(&JsValue::from("passed"), &passed.into());
@@ -53,8 +55,15 @@ impl From<VerificationResult> for JsValue {
                 let verification_version_entry =
                     Array::of2(&JsValue::from("verificationVersion"), &verification_version);
 
-                Object::from_entries(&Array::of2(&passed_entry, &verification_version_entry))
-                    .unwrap()
+                let reason = JsValue::from(reason);
+                let reason_entry = Array::of2(&JsValue::from("reason"), &reason.into());
+
+                Object::from_entries(&Array::of3(
+                    &passed_entry,
+                    &verification_version_entry,
+                    &reason_entry,
+                ))
+                .unwrap()
             }
             VerificationResult::Passed {
                 verification_version,

--- a/packages/ic-response-verification/tests/v1_response_verification.rs
+++ b/packages/ic-response-verification/tests/v1_response_verification.rs
@@ -231,7 +231,8 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(matches!(
             result,
@@ -287,7 +288,8 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(matches!(
             result,
@@ -347,7 +349,8 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(matches!(
             result,

--- a/packages/ic-response-verification/tests/v1_response_verification.rs
+++ b/packages/ic-response-verification/tests/v1_response_verification.rs
@@ -183,7 +183,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 1
+                reason
+            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidResponseBody)
         ));
     }
 
@@ -230,11 +231,14 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        );
+        ).unwrap();
 
         assert!(matches!(
             result,
-            Err(ResponseVerificationError::CertificateVerificationFailed)
+            VerificationResult::Failed {
+                verification_version,
+                reason
+            } if verification_version == 1 && matches!(reason, ResponseVerificationError::CertificateVerificationFailed)
         ));
     }
 
@@ -283,15 +287,18 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        );
+        ).unwrap();
 
         assert!(matches!(
             result,
-            Err(ResponseVerificationError::CertificateTimeTooFarInTheFuture {
+            VerificationResult::Failed {
+                verification_version,
+                reason
+            } if verification_version == 1 && matches!(reason, ResponseVerificationError::CertificateTimeTooFarInTheFuture {
                 certificate_time,
                 max_certificate_time
-            }) if certificate_time == certificate_time &&
-                max_certificate_time == current_time + MAX_CERT_TIME_OFFSET_NS
+            } if certificate_time == certificate_time &&
+            max_certificate_time == current_time + MAX_CERT_TIME_OFFSET_NS)
         ));
     }
 
@@ -340,15 +347,21 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        );
+        ).unwrap();
 
         assert!(matches!(
             result,
-            Err(ResponseVerificationError::CertificateTimeTooFarInThePast {
-                certificate_time,
-                min_certificate_time
-            }) if certificate_time == certificate_time &&
-                min_certificate_time == current_time - MAX_CERT_TIME_OFFSET_NS
+            VerificationResult::Failed {
+                verification_version,
+                reason,
+            } if verification_version == 1 && matches!(
+                reason,
+                ResponseVerificationError::CertificateTimeTooFarInThePast {
+                    certificate_time,
+                    min_certificate_time
+                } if certificate_time == certificate_time &&
+                    min_certificate_time == current_time - MAX_CERT_TIME_OFFSET_NS
+            )
         ));
     }
 
@@ -402,7 +415,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 1
+                reason,
+            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidTree)
         ));
     }
 
@@ -457,7 +471,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 1
+                reason,
+            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidTree)
         ));
     }
 
@@ -510,7 +525,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 1
+                reason,
+            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidResponseBody)
         ));
     }
 

--- a/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
@@ -183,6 +183,7 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
+                reason: _,
             } if verification_version == 2
         ));
     }
@@ -291,6 +292,7 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
+                reason: _
             } if verification_version == 2
         ));
     }

--- a/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
@@ -9,7 +9,7 @@ mod tests {
         cel::cel_to_certification,
         hash::{request_hash, response_hash},
         types::{Request, Response, VerificationResult},
-        verify_request_response_pair,
+        verify_request_response_pair, ResponseVerificationError,
     };
     use ic_response_verification_test_utils::{
         create_expr_tree_path, create_v2_certificate_fixture, create_v2_fixture, create_v2_header,
@@ -79,7 +79,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 2
+                reason,
+            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidResponseHashes)
         ));
     }
 
@@ -146,7 +147,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 2
+                reason,
+            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidResponseHashes)
         ));
     }
 
@@ -218,7 +220,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 2
+                reason,
+            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidExpressionPath)
         ));
     }
 
@@ -295,7 +298,8 @@ mod tests {
             result,
             VerificationResult::Failed {
                 verification_version,
-            } if verification_version == 2
+                reason,
+            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidExpressionPath)
         ));
     }
 
@@ -344,9 +348,12 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        );
+        ).unwrap();
 
-        assert!(result.is_err());
+        assert!(matches!(result, VerificationResult::Failed {
+            verification_version,
+            reason: _,
+        } if verification_version == 2))
     }
 }
 

--- a/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
@@ -348,7 +348,8 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(matches!(result, VerificationResult::Failed {
             verification_version,


### PR DESCRIPTION
Updated the verification error handling to include a reason when verification fails. This now means that all verification related issues are not thrown anymore, instead they are include in the `reason` property of the response.

The errors that are still thrown are now related to the parsing logic before the [verification](https://github.com/dfinity/response-verification/blob/kepler/tt-79-errors/packages/ic-response-verification/src/verification/verify_request_response_pair.rs#L83) method is called upon or the verification version is not supported (this case still results in the error `UnsupportedVerificationVersion`)