### PR TITLE
fix: add missing request body hashing

### DIFF
--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
         method: "GET".into(),
         url: http_request.url,
         headers: http_request.headers,
+        body: vec![],
     };
     println!("***Request***");
     println!("Url: {:?}", request.url);

--- a/packages/ic-response-verification-tests/src/main.rs
+++ b/packages/ic-response-verification-tests/src/main.rs
@@ -103,6 +103,7 @@ async fn perform_test(
         method: "GET".into(),
         headers: vec![],
         url: path.into(),
+        body: vec![],
     };
     let response = Response {
         headers: response

--- a/packages/ic-response-verification-tests/wasm-tests/main.ts
+++ b/packages/ic-response-verification-tests/wasm-tests/main.ts
@@ -112,6 +112,7 @@ async function performTest(
     headers: httpRequest.headers,
     method: httpRequest.method,
     url: httpRequest.url,
+    body: httpRequest.body,
   };
   let response: Response = {
     body: httpResponse.body,

--- a/packages/ic-response-verification-wasm/Cargo.lock
+++ b/packages/ic-response-verification-wasm/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "flate2",
+ "hex",
  "http",
  "ic-certification",
  "ic-representation-independent-hash",

--- a/packages/ic-response-verification/Cargo.toml
+++ b/packages/ic-response-verification/Cargo.toml
@@ -35,6 +35,7 @@ flate2 = "1.0.24"
 leb128 = "0.2.5"
 candid = "0.8.4"
 log = { version = "0.4.17", features = ["max_level_off", "release_max_level_off"] }
+hex = "0.4.3"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/packages/ic-response-verification/src/hash/response_hash.rs
+++ b/packages/ic-response-verification/src/hash/response_hash.rs
@@ -120,7 +120,6 @@ pub fn response_hash(
     response: &Response,
     response_certification: &ResponseCertification,
 ) -> Sha256Digest {
-    // lower case the headers here
     let filtered_headers = filter_response_headers(response, response_certification);
     let concatenated_hashes = [
         response_headers_hash(&response.status_code.into(), &filtered_headers),

--- a/packages/ic-response-verification/src/hash/response_hash.rs
+++ b/packages/ic-response-verification/src/hash/response_hash.rs
@@ -120,6 +120,7 @@ pub fn response_hash(
     response: &Response,
     response_certification: &ResponseCertification,
 ) -> Sha256Digest {
+    // lower case the headers here
     let filtered_headers = filter_response_headers(response, response_certification);
     let concatenated_hashes = [
         response_headers_hash(&response.status_code.into(), &filtered_headers),

--- a/packages/ic-response-verification/src/types/response.rs
+++ b/packages/ic-response-verification/src/types/response.rs
@@ -18,7 +18,7 @@ pub struct Response {
     pub status_code: u16,
     /// The HTTP headers of the request, i.e. \[\["Ic-Certificate", "certificate=:2dn3o2R0cmVlgw=:, tree=:2dn3gwGDA:"\]\]
     pub headers: Vec<(String, String)>,
-    /// The body of the request as a candid decoded blob, i.e.  \[60, 33, 100, 111, 99\]
+    /// The body of the request as an array of bytes, i.e. \[60, 33, 100, 111, 99\]
     pub body: Vec<u8>,
 }
 

--- a/packages/ic-response-verification/tests/v1_response_verification.rs
+++ b/packages/ic-response-verification/tests/v1_response_verification.rs
@@ -42,6 +42,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -101,6 +102,7 @@ mod tests {
             url: "/".into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -160,6 +162,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -215,6 +218,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -272,6 +276,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -333,6 +338,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -395,6 +401,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -451,6 +458,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -505,6 +513,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {
@@ -559,6 +568,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
 
         let response = Response {

--- a/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
@@ -52,6 +52,7 @@ mod tests {
                 ("Accept".into(), "text/html".into()),
                 ("Accept-Encoding".into(), "gzip, deflate, br".into()),
             ],
+            body: vec![],
         };
 
         let current_time = get_current_timestamp();
@@ -150,6 +151,7 @@ mod tests {
                 ("Accept".into(), "text/html".into()),
                 ("Accept-Encoding".into(), "gzip, deflate, br".into()),
             ],
+            body: vec![],
         };
 
         let current_time = get_current_timestamp();
@@ -441,6 +443,7 @@ mod fixtures {
                 ("Accept-Encoding".into(), "gzip, deflate, br".into()),
                 ("If-None-Match".into(), etag),
             ],
+            body: vec![],
         }
     }
 
@@ -473,6 +476,7 @@ mod fixtures {
                     "5fd924625f6ab16a19cc9807c7c506ae1813490e4ba675f843d5a10e0baacdb8".into(),
                 ),
             ],
+            body: vec![],
         }
     }
 

--- a/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
@@ -33,6 +33,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -102,6 +103,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -192,6 +194,7 @@ mod tests {
                 ("Cache-Control".into(), "no-cache".into()),
                 ("Cache-Control".into(), "no-store".into()),
             ],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -276,6 +279,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,

--- a/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
@@ -34,6 +34,7 @@ mod tests {
                 ("Cache-Control".into(), "no-cache".into()),
                 ("Cache-Control".into(), "no-store".into()),
             ],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -102,6 +103,7 @@ mod tests {
                 ("Cache-Control".into(), "no-cache".into()),
                 ("Cache-Control".into(), "no-store".into()),
             ],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -172,6 +174,7 @@ mod tests {
                 ("Cache-Control".into(), "no-cache".into()),
                 ("Cache-Control".into(), "no-store".into()),
             ],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -239,6 +242,7 @@ mod tests {
             url: "/assets/js/app.js".to_string(),
             method: "GET".to_string(),
             headers: vec![],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,
@@ -341,6 +345,7 @@ mod tests {
             url: path.into(),
             method: "GET".into(),
             headers: vec![],
+            body: vec![],
         };
         let mut response = Response {
             status_code: 200,


### PR DESCRIPTION
Request body hashing is part of the spec, but has not been part of the implementation: https://github.com/dfinity/interface-spec/blob/master/spec/http-gateway-protocol-spec.md#request-hash-calculation

Thankfully nobody is using this yet 🙃 