### PR TITLE
feat: enable web logs and panic hook for response verification library

### DIFF
--- a/packages/ic-response-verification-wasm/Cargo.lock
+++ b/packages/ic-response-verification-wasm/Cargo.lock
@@ -1102,7 +1102,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-console-logger",
  "wasm-bindgen-test",
- "wee_alloc",
 ]
 
 [[package]]
@@ -1373,12 +1372,6 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "minimal-lexical"
@@ -2431,18 +2424,6 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
 ]
 
 [[package]]

--- a/packages/ic-response-verification-wasm/Cargo.toml
+++ b/packages/ic-response-verification-wasm/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 include = ["src", "Cargo.toml", "README.md"]
 
 [features]
-debug = ["dep:log", "dep:wasm-bindgen-console-logger", "ic-response-verification/debug"]
+debug = ["ic-response-verification/debug"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -26,9 +26,8 @@ ic-response-verification = { path = "../ic-response-verification", features = ["
 console_error_panic_hook = "0.1.7"
 js-sys = "0.3"
 wasm-bindgen = "0.2.83"
-wee_alloc = "0.4.5"
-log = { version = "0.4.17", optional = true }
-wasm-bindgen-console-logger = { version = "0.1.1", optional = true }
+log = "0.4.17"
+wasm-bindgen-console-logger = "0.1.1"
 
 [dev-dependencies]
 base64 = "0.21.0"

--- a/packages/ic-response-verification-wasm/src/lib.rs
+++ b/packages/ic-response-verification-wasm/src/lib.rs
@@ -1,14 +1,9 @@
-use ic_response_verification::ResponseVerificationJsError;
-use ic_response_verification::types::VerificationResult;
-use ic_response_verification::types::Request;
-use ic_response_verification::types::Response;
-use ic_response_verification::verify_request_response_pair as verify_request_response_pair_impl;
-use ic_response_verification::{ MIN_VERIFICATION_VERSION, MAX_VERIFICATION_VERSION };
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+use ic_response_verification::{
+    types::{Request, Response, VerificationResult},
+    verify_request_response_pair as verify_request_response_pair_impl, ResponseVerificationJsError,
+    MAX_VERIFICATION_VERSION, MIN_VERIFICATION_VERSION,
+};
+use wasm_bindgen::{prelude::*, JsCast};
 
 #[wasm_bindgen]
 extern "C" {
@@ -44,10 +39,7 @@ pub fn verify_request_response_pair(
     ic_public_key: &[u8],
     min_requested_verification_version: u8,
 ) -> Result<JsVerificationResult, ResponseVerificationJsError> {
-    #[cfg(feature = "debug")]
     console_error_panic_hook::set_once();
-
-    #[cfg(feature = "debug")]
     log::set_logger(&wasm_bindgen_console_logger::DEFAULT_LOGGER).unwrap();
 
     let request = Request::from(JsValue::from(request));
@@ -63,7 +55,8 @@ pub fn verify_request_response_pair(
         min_requested_verification_version,
     )
     .map(|verification_result| {
-        JsValue::from(VerificationResult::from(verification_result)).unchecked_into::<JsVerificationResult>()
+        JsValue::from(VerificationResult::from(verification_result))
+            .unchecked_into::<JsVerificationResult>()
     })
     .map_err(|e| ResponseVerificationJsError::from(e))
 }


### PR DESCRIPTION
File size before any changes: 231kb

After adding logger and panic hook: 238kb
So that's an additional 7kb.

After reverting back to the default allocator: 244kb
So that's an additional 6kb.

Totaling an extra 13kb. I don't think anyone will notice :) 