### PR TITLE
feat: always return a result/exception when response verification fails

### DIFF
--- a/packages/ic-response-verification-tests/src/main.rs
+++ b/packages/ic-response-verification-tests/src/main.rs
@@ -2,7 +2,7 @@ use crate::agent::create_agent;
 use anyhow::{anyhow, Result};
 use ic_agent::export::Principal;
 use ic_agent::Agent;
-use ic_response_verification::types::{Request, Response, VerificationResult};
+use ic_response_verification::types::{Request, Response, VerificationInfo};
 use ic_utils::call::SyncCall;
 use ic_utils::interfaces::http_request::HeaderField;
 use ic_utils::interfaces::HttpRequestCanister;
@@ -54,7 +54,7 @@ async fn v1_test(canister_id: &str, agent: &Agent) -> Result<()> {
     let (result, _response) = perform_test(canister_id, "GET", "/", None, agent).await?;
     assert!(matches!(
         result,
-        VerificationResult::Passed {
+        VerificationInfo {
             verification_version,
             response: _,
         } if verification_version == 1
@@ -64,7 +64,7 @@ async fn v1_test(canister_id: &str, agent: &Agent) -> Result<()> {
         perform_test(canister_id, "GET", "/sample-asset.txt", None, agent).await?;
     assert!(matches!(
         result,
-        VerificationResult::Passed {
+        VerificationInfo {
             verification_version,
             response: _,
         } if verification_version == 1
@@ -108,7 +108,7 @@ async fn v2_load_asset(
 
     assert!(matches!(
         result,
-        VerificationResult::Passed {
+        VerificationInfo {
             verification_version,
             response: _,
         } if verification_version == 2
@@ -124,7 +124,7 @@ async fn perform_test(
     path: &str,
     certificate_version: Option<&u16>,
     agent: &Agent,
-) -> Result<(VerificationResult, Response)> {
+) -> Result<(VerificationInfo, Response)> {
     let canister_id = Principal::from_text(canister_id)?;
     let canister_interface = HttpRequestCanister::create(agent, canister_id);
 

--- a/packages/ic-response-verification-tests/wasm-tests/main.ts
+++ b/packages/ic-response-verification-tests/wasm-tests/main.ts
@@ -1,5 +1,5 @@
 import {
-  VerificationResult,
+  VerificationInfo,
   Request,
   Response,
   getMinVerificationVersion,
@@ -15,6 +15,7 @@ import {
 import { HttpAgent, ActorSubclass, Actor, Agent } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import assert from 'node:assert';
+import { exit } from 'process';
 
 async function createAgentAndActor(
   gatewayUrl: string,
@@ -49,6 +50,7 @@ async function main(): Promise<void> {
     await v2Test(principal, agent, actor);
   } catch (error) {
     console.error('Error running e2e tests...', error);
+    exit(1);
   }
 }
 
@@ -65,7 +67,6 @@ async function v1Test(
     agent,
     actor,
   );
-  assert(resultOne.passed);
   assert.equal(resultOne.verificationVersion, 1);
 
   const resultTwo = await performTest(
@@ -76,7 +77,6 @@ async function v1Test(
     agent,
     actor,
   );
-  assert(resultTwo.passed);
   assert.equal(resultTwo.verificationVersion, 1);
 }
 
@@ -86,11 +86,9 @@ async function v2Test(
   actor: ActorSubclass<_SERVICE>,
 ): Promise<void> {
   const resultOne = await performTest(canisterId, 'GET', '/', 2, agent, actor);
-  assert(resultOne.passed);
   assert.equal(resultOne.verificationVersion, 2);
 
   const resultTwo = await performTest(canisterId, 'GET', '/', 2, agent, actor);
-  assert(resultTwo.passed);
   assert.equal(resultTwo.verificationVersion, 2);
 }
 
@@ -101,7 +99,7 @@ async function performTest(
   certificateVersion: number | null,
   agent: Agent,
   actor: ActorSubclass<_SERVICE>,
-): Promise<VerificationResult> {
+): Promise<VerificationInfo> {
   let httpRequest: HttpRequest = {
     method,
     body: new Uint8Array(),

--- a/packages/ic-response-verification-wasm/src/lib.rs
+++ b/packages/ic-response-verification-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use ic_response_verification::{
-    types::{Request, Response, VerificationResult},
+    types::{Request, Response, VerificationInfo},
     verify_request_response_pair as verify_request_response_pair_impl, ResponseVerificationJsError,
     MAX_VERIFICATION_VERSION, MIN_VERIFICATION_VERSION,
 };
@@ -7,8 +7,8 @@ use wasm_bindgen::{prelude::*, JsCast};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "VerificationResult")]
-    pub type JsVerificationResult;
+    #[wasm_bindgen(typescript_type = "VerificationInfo")]
+    pub type JsVerificationInfo;
 
     #[wasm_bindgen(typescript_type = "Request")]
     pub type JsRequest;
@@ -27,6 +27,13 @@ pub fn get_max_verification_version() -> u8 {
     return MAX_VERIFICATION_VERSION;
 }
 
+#[wasm_bindgen(start)]
+pub fn main() {
+    console_error_panic_hook::set_once();
+    log::set_logger(&wasm_bindgen_console_logger::DEFAULT_LOGGER).unwrap();
+    log::set_max_level(log::LevelFilter::Trace);
+}
+
 /// The primary entry point for verifying a request and response pair. This will verify the response
 /// with respect to the request, according the [Response Verification Spec]().
 #[wasm_bindgen(js_name = verifyRequestResponsePair)]
@@ -38,10 +45,7 @@ pub fn verify_request_response_pair(
     max_cert_time_offset_ns: u64,
     ic_public_key: &[u8],
     min_requested_verification_version: u8,
-) -> Result<JsVerificationResult, ResponseVerificationJsError> {
-    console_error_panic_hook::set_once();
-    log::set_logger(&wasm_bindgen_console_logger::DEFAULT_LOGGER).unwrap();
-
+) -> Result<JsVerificationInfo, ResponseVerificationJsError> {
     let request = Request::from(JsValue::from(request));
     let response = Response::from(JsValue::from(response));
 
@@ -55,8 +59,8 @@ pub fn verify_request_response_pair(
         min_requested_verification_version,
     )
     .map(|verification_result| {
-        JsValue::from(VerificationResult::from(verification_result))
-            .unchecked_into::<JsVerificationResult>()
+        JsValue::from(VerificationInfo::from(verification_result))
+            .unchecked_into::<JsVerificationInfo>()
     })
     .map_err(|e| ResponseVerificationJsError::from(e))
 }

--- a/packages/ic-response-verification/src/cbor/hash_tree.rs
+++ b/packages/ic-response-verification/src/cbor/hash_tree.rs
@@ -23,21 +23,21 @@ pub fn parsed_cbor_to_tree(parsed_cbor: &CborValue) -> Result<HashTree, Response
         cbor_tags.reverse();
 
         if let Some(CborValue::HashTree(hash_tree_tag)) = cbor_tags.pop() {
-            return match hash_tree_tag {
+            match hash_tree_tag {
                 CborHashTree::Empty => Ok(empty()),
 
                 CborHashTree::Leaf => {
-                    return if let Some(CborValue::ByteString(data)) = cbor_tags.pop() {
+                    if let Some(CborValue::ByteString(data)) = cbor_tags.pop() {
                         Ok(leaf(data))
                     } else {
                         Err(ResponseVerificationError::MalformedHashTree(String::from(
                             "Missing ByteString for Leaf node",
                         )))
-                    };
+                    }
                 }
 
                 CborHashTree::Pruned => {
-                    return if let Some(CborValue::ByteString(data)) = cbor_tags.pop() {
+                    if let Some(CborValue::ByteString(data)) = cbor_tags.pop() {
                         let digest: Sha256Digest = TryFrom::<&[u8]>::try_from(data.as_ref())
                             .map_err(ResponseVerificationError::IncorrectPrunedDataLength)?;
 
@@ -46,11 +46,11 @@ pub fn parsed_cbor_to_tree(parsed_cbor: &CborValue) -> Result<HashTree, Response
                         Err(ResponseVerificationError::MalformedHashTree(String::from(
                             "Missing ByteString for Pruned node",
                         )))
-                    };
+                    }
                 }
 
                 CborHashTree::Labelled => {
-                    return if let (Some(CborValue::ByteString(data)), Some(child_tag)) =
+                    if let (Some(CborValue::ByteString(data)), Some(child_tag)) =
                         (cbor_tags.pop(), cbor_tags.pop())
                     {
                         let node_label = Label::from(data);
@@ -61,13 +61,11 @@ pub fn parsed_cbor_to_tree(parsed_cbor: &CborValue) -> Result<HashTree, Response
                         Err(ResponseVerificationError::MalformedHashTree(String::from(
                             "Missing ByteString or child node for Labelled node",
                         )))
-                    };
+                    }
                 }
 
                 CborHashTree::Fork => {
-                    return if let (Some(left_tag), Some(right_tag)) =
-                        (cbor_tags.pop(), cbor_tags.pop())
-                    {
+                    if let (Some(left_tag), Some(right_tag)) = (cbor_tags.pop(), cbor_tags.pop()) {
                         let left = parsed_cbor_to_tree(&left_tag)?;
                         let right = parsed_cbor_to_tree(&right_tag)?;
 
@@ -76,9 +74,9 @@ pub fn parsed_cbor_to_tree(parsed_cbor: &CborValue) -> Result<HashTree, Response
                         Err(ResponseVerificationError::MalformedHashTree(String::from(
                             "Missing child nodes for Fork node",
                         )))
-                    };
+                    }
                 }
-            };
+            }
         } else {
             Err(ResponseVerificationError::MalformedHashTree(String::from(
                 "Expected Hash Tree cbor tag",

--- a/packages/ic-response-verification/src/test_utils.rs
+++ b/packages/ic-response-verification/src/test_utils.rs
@@ -2,6 +2,7 @@
 pub mod test_utils {
     use ic_certification::hash_tree::{fork, label, leaf, pruned_from_hex, Sha256Digest};
     use ic_certification::{Certificate, Delegation, HashTree};
+    use ic_response_verification_test_utils::base64_encode;
 
     pub struct CreateTreeOptions<'a> {
         pub path: Option<&'a str>,
@@ -136,7 +137,7 @@ pub mod test_utils {
     }
 
     pub fn create_encoded_header_field<T: AsRef<[u8]>>(name: &str, value: T) -> String {
-        let value = base64::encode(value);
+        let value = base64_encode(value.as_ref());
 
         create_header_field(name, &value)
     }

--- a/packages/ic-response-verification/src/types/verification_result.rs
+++ b/packages/ic-response-verification/src/types/verification_result.rs
@@ -1,95 +1,43 @@
-use crate::{types::VerifiedResponse, ResponseVerificationError};
+use crate::types::VerifiedResponse;
 
 #[cfg(all(target_arch = "wasm32", feature = "js"))]
 use wasm_bindgen::prelude::*;
 
 #[cfg(all(target_arch = "wasm32", feature = "js"))]
-use crate::ResponseVerificationJsError;
-
-#[cfg(all(target_arch = "wasm32", feature = "js"))]
 #[wasm_bindgen(typescript_custom_section)]
 const VERIFICATION_RESULT: &'static str = r#"
-type VerificationResult = {
-  passed: true;
+type VerificationInfo = {
   response?: VerifiedResponse;
   verificationVersion: number;
-} | {
-  passed: false;
-  verificationVersion: number;
-  reason: ResponseVerificationError;
 }
 "#;
 
 /// Result of verifying the provided request/response pair's certification.
 #[derive(Debug)]
-pub enum VerificationResult {
-    /// Verification passed
-    Passed {
-        /// Response object including the status code, body and headers that were included in the
-        /// certification and passed verification. If verification failed then this object will be
-        /// empty.
-        response: Option<VerifiedResponse>,
-        /// The version of verification that was used to verify the response
-        verification_version: u16,
-    },
-    /// Verification failed
-    Failed {
-        /// The version of verification that was used to verify the response
-        verification_version: u16,
-        /// The reason why the verification of the response has failed
-        reason: ResponseVerificationError,
-    },
+pub struct VerificationInfo {
+    /// Response object including the status code, body and headers that were included in the
+    /// certification and passed verification. If verification failed then this object will be
+    /// empty.
+    pub response: Option<VerifiedResponse>,
+    /// The version of verification that was used to verify the response
+    pub verification_version: u16,
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "js"))]
-impl From<VerificationResult> for JsValue {
-    fn from(verification_result: VerificationResult) -> Self {
-        use js_sys::{Array, Boolean, Number, Object};
+impl From<VerificationInfo> for JsValue {
+    fn from(verification_result: VerificationInfo) -> Self {
+        use js_sys::{Array, Number, Object};
 
-        let result = match verification_result {
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } => {
-                let passed = Boolean::from(false);
-                let passed_entry = Array::of2(&JsValue::from("passed"), &passed.into());
+        let verification_version = Number::from(verification_result.verification_version);
+        let verification_version_entry =
+            Array::of2(&JsValue::from("verificationVersion"), &verification_version);
 
-                let verification_version = Number::from(verification_version);
-                let verification_version_entry =
-                    Array::of2(&JsValue::from("verificationVersion"), &verification_version);
+        let response = JsValue::from(verification_result.response);
+        let response_entry = Array::of2(&JsValue::from("response"), &response.into());
 
-                let reason = JsValue::from(ResponseVerificationJsError::from(reason));
-                let reason_entry = Array::of2(&JsValue::from("reason"), &reason.into());
-
-                Object::from_entries(&Array::of3(
-                    &passed_entry,
-                    &verification_version_entry,
-                    &reason_entry,
-                ))
-                .unwrap()
-            }
-            VerificationResult::Passed {
-                verification_version,
-                response,
-            } => {
-                let passed = Boolean::from(true);
-                let passed_entry = Array::of2(&JsValue::from("passed"), &passed.into());
-
-                let verification_version = Number::from(verification_version);
-                let verification_version_entry =
-                    Array::of2(&JsValue::from("verificationVersion"), &verification_version);
-
-                let response = JsValue::from(response);
-                let response_entry = Array::of2(&JsValue::from("response"), &response.into());
-
-                Object::from_entries(&Array::of3(
-                    &passed_entry,
-                    &response_entry,
-                    &verification_version_entry,
-                ))
-                .unwrap()
-            }
-        };
+        let result =
+            Object::from_entries(&Array::of2(&response_entry, &verification_version_entry))
+                .unwrap();
 
         JsValue::from(result)
     }
@@ -97,7 +45,7 @@ impl From<VerificationResult> for JsValue {
 
 #[cfg(all(target_arch = "wasm32", feature = "js", test))]
 mod tests {
-    use crate::types::{VerificationResult, VerifiedResponse};
+    use crate::types::{VerificationInfo, VerifiedResponse};
     use crate::ResponseVerificationError;
     use js_sys::JSON;
     use wasm_bindgen::JsValue;
@@ -105,10 +53,10 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn serialize_verification_result_with_no_response() {
-        let expected = r#"{"passed":true,"verificationVersion":1}"#;
+        let expected = r#"{"verificationVersion":1}"#;
 
         assert_eq!(
-            JSON::stringify(&JsValue::from(VerificationResult::Passed {
+            JSON::stringify(&JsValue::from(VerificationInfo {
                 response: None,
                 verification_version: 1,
             }))
@@ -119,30 +67,16 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn serialize_verification_result_with_response() {
-        let expected = r#"{"passed":true,"response":{"statusCode":200,"body":{"0":0,"1":1,"2":2},"headers":[]},"verificationVersion":2}"#;
+        let expected = r#"{"response":{"statusCode":200,"body":{"0":0,"1":1,"2":2},"headers":[]},"verificationVersion":2}"#;
 
         assert_eq!(
-            JSON::stringify(&JsValue::from(VerificationResult::Passed {
+            JSON::stringify(&JsValue::from(VerificationInfo {
                 response: Some(VerifiedResponse {
                     status_code: Some(200),
                     body: vec![0, 1, 2],
                     headers: vec![],
                 }),
                 verification_version: 2,
-            }))
-            .unwrap(),
-            expected
-        );
-    }
-
-    #[wasm_bindgen_test]
-    fn serialize_failed_verification_result() {
-        let expected = r#"{"passed":false,"verificationVersion":2,"reason":{"code":27,"message":"Invalid response hashes"}}"#;
-
-        assert_eq!(
-            JSON::stringify(&JsValue::from(VerificationResult::Failed {
-                verification_version: 2,
-                reason: ResponseVerificationError::InvalidResponseHashes
             }))
             .unwrap(),
             expected

--- a/packages/ic-response-verification/src/validation/common_validation.rs
+++ b/packages/ic-response-verification/src/validation/common_validation.rs
@@ -140,7 +140,7 @@ pub fn validate_certificate_time(
 pub fn validate_tree(canister_id: &[u8], certificate: &Certificate, tree: &HashTree) -> bool {
     let certified_data_path = [
         "canister".as_bytes(),
-        canister_id.as_ref(),
+        canister_id,
         "certified_data".as_bytes(),
     ];
 

--- a/packages/ic-response-verification/src/validation/v2_validation.rs
+++ b/packages/ic-response-verification/src/validation/v2_validation.rs
@@ -115,10 +115,10 @@ pub fn validate_expr_path(expr_path: &[String], request_url: &http::Uri, tree: &
     path_exists_in_tree(&original_path, tree)
 }
 
-pub fn validate_expr_hash<'a>(
+pub fn validate_expr_hash(
     expr_path: &[String],
     expr_hash: &Sha256Digest,
-    tree: &'a HashTree,
+    tree: &HashTree,
 ) -> Option<HashTree> {
     let mut path = path_from_parts(expr_path);
     path.push(expr_hash.into());

--- a/packages/ic-response-verification/src/verification/certificate_header_field.rs
+++ b/packages/ic-response-verification/src/verification/certificate_header_field.rs
@@ -52,6 +52,7 @@ mod tests {
     use crate::test_utils::test_utils::{
         cbor_encode, create_certificate, create_encoded_header_field,
     };
+    use ic_response_verification_test_utils::base64_encode;
 
     #[test]
     fn certificate_header_field_parses_valid_field() {
@@ -63,7 +64,7 @@ mod tests {
             CertificateHeaderField::from(header_field.as_str()).unwrap();
 
         assert_eq!(result_name, name);
-        assert_eq!(result_value, base64::encode(value));
+        assert_eq!(result_value, base64_encode(&value));
     }
 
     #[test]
@@ -99,7 +100,7 @@ mod tests {
     fn certificate_header_field_does_not_parse_invalid_field() {
         let name = "certificate";
         let value = cbor_encode(&create_certificate(None));
-        let value = base64::encode(value);
+        let value = base64_encode(&value);
 
         let header_field = format!("{}:{}", name, value);
 

--- a/packages/ic-response-verification/tests/v1_response_verification.rs
+++ b/packages/ic-response-verification/tests/v1_response_verification.rs
@@ -1,9 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
     use ic_certification_testing::{CertificateBuilder, CertificateData};
-    use ic_response_verification::types::{
-        Request, Response, VerificationResult, VerifiedResponse,
-    };
+    use ic_response_verification::types::{Request, Response, VerificationInfo, VerifiedResponse};
     use ic_response_verification::verify_request_response_pair;
     use ic_response_verification::ResponseVerificationError;
     use ic_response_verification_test_utils::{
@@ -71,7 +69,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 1 && response == Some(expected_response)
@@ -133,7 +131,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 1 && response == Some(expected_response)
@@ -185,15 +183,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason
-            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidResponseBody)
+            Err(ResponseVerificationError::InvalidResponseBody)
         ));
     }
 
@@ -243,15 +237,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason
-            } if verification_version == 1 && matches!(reason, ResponseVerificationError::CertificateVerificationFailed)
+            Err(ResponseVerificationError::CertificateVerificationFailed)
         ));
     }
 
@@ -303,19 +293,15 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason
-            } if verification_version == 1 && matches!(reason, ResponseVerificationError::CertificateTimeTooFarInTheFuture {
+            Err(ResponseVerificationError::CertificateTimeTooFarInTheFuture {
                 certificate_time,
                 max_certificate_time
-            } if certificate_time == certificate_time &&
-            max_certificate_time == current_time + MAX_CERT_TIME_OFFSET_NS)
+            }) if certificate_time == certificate_time &&
+            max_certificate_time == current_time + MAX_CERT_TIME_OFFSET_NS
         ));
     }
 
@@ -367,22 +353,15 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 1 && matches!(
-                reason,
-                ResponseVerificationError::CertificateTimeTooFarInThePast {
-                    certificate_time,
-                    min_certificate_time
-                } if certificate_time == certificate_time &&
-                    min_certificate_time == current_time - MAX_CERT_TIME_OFFSET_NS
-            )
+            Err(ResponseVerificationError::CertificateTimeTooFarInThePast {
+                certificate_time,
+                min_certificate_time
+            }) if certificate_time == certificate_time &&
+            min_certificate_time == current_time - MAX_CERT_TIME_OFFSET_NS
         ));
     }
 
@@ -432,15 +411,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidTree)
+            Err(ResponseVerificationError::InvalidTree)
         ));
     }
 
@@ -491,15 +466,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidTree)
+            Err(ResponseVerificationError::InvalidTree)
         ));
     }
 
@@ -548,15 +519,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 1 && matches!(reason, ResponseVerificationError::InvalidResponseBody)
+            Err(ResponseVerificationError::InvalidResponseBody)
         ));
     }
 

--- a/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
@@ -11,7 +11,7 @@ mod tests {
         etag_certificate_tree, index_js_response, not_found_response, redirect_response,
     };
     use ic_response_verification::{
-        types::{Request, Response, VerificationResult, VerifiedResponse},
+        types::{Request, Response, VerificationInfo, VerifiedResponse},
         verify_request_response_pair, ResponseVerificationError,
     };
     use ic_response_verification_test_utils::{
@@ -97,7 +97,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 2 && response == Some(expected_certified_response)
@@ -106,43 +106,42 @@ mod tests {
 
     #[rstest]
     // assert that the asset not found response is not accepted for assets outside the js folder
-    #[case::not_found_for_index_html_path(&"/", &["js",  "<*>"], not_found_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::not_found_for_not_found_path(&"/not-found", &["js",  "<*>"], not_found_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::not_found_for_not_found_trailing_slash_path(&"/not-found/", &["js",  "<*>"], not_found_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::not_found_for_nested_not_found_path(&"/not/found", &["js",  "<*>"], not_found_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::not_found_for_nested_not_found_trailing_slash_path(&"/not/found/", &["js",  "<*>"], not_found_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::not_found_for_old_path(&"/old-path", &["js",  "<*>"], not_found_response(), ResponseVerificationError::InvalidExpressionPath)]
+    #[case::not_found_for_index_html_path(&"/", &["js",  "<*>"], not_found_response())]
+    #[case::not_found_for_not_found_path(&"/not-found", &["js",  "<*>"], not_found_response())]
+    #[case::not_found_for_not_found_trailing_slash_path(&"/not-found/", &["js",  "<*>"], not_found_response())]
+    #[case::not_found_for_nested_not_found_path(&"/not/found", &["js",  "<*>"], not_found_response())]
+    #[case::not_found_for_nested_not_found_trailing_slash_path(&"/not/found/", &["js",  "<*>"], not_found_response())]
+    #[case::not_found_for_old_path(&"/old-path", &["js",  "<*>"], not_found_response())]
     // assert that the index html fallback response is not accepted for assets inside the js folder
-    #[case::index_html_for_js_path(&"/js/index.js", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::index_html_for_js_not_found_path(&"/js/not-found", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::index_html_for_js_not_found_trailing_slash_path(&"/js/not-found/", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::index_html_for_js_nested_not_found_path(&"/js/not/found", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::index_html_for_js_nested_not_found_trailing_slash_path(&"/js/not/found/", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::index_html_for_old_path(&"/old-path", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
+    #[case::index_html_for_js_path(&"/js/index.js", &["<*>"], index_html_response())]
+    #[case::index_html_for_js_not_found_path(&"/js/not-found", &["<*>"], index_html_response())]
+    #[case::index_html_for_js_not_found_trailing_slash_path(&"/js/not-found/", &["<*>"], index_html_response())]
+    #[case::index_html_for_js_nested_not_found_path(&"/js/not/found", &["<*>"], index_html_response())]
+    #[case::index_html_for_js_nested_not_found_trailing_slash_path(&"/js/not/found/", &["<*>"], index_html_response())]
+    #[case::index_html_for_old_path(&"/old-path", &["<*>"], index_html_response())]
     // assert that the redirect response is not accepted for incorrect paths
-    #[case::redirect_for_old_trailing_slash_path(&"/old-path/", &["old-path", "<$>"], redirect_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::redirect_for_index_html_path(&"/", &["old-path", "<$>"], redirect_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::redirect_for_not_found_path(&"/not-found", &["old-path", "<$>"], redirect_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::redirect_for_nested_not_found_path(&"/not/found", &["old-path", "<$>"], redirect_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::redirect_for_js_path(&"/js/index.js", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::redirect_for_js_not_found_path(&"/js/not-found", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::redirect_for_js_nested_not_found_path(&"/js/not/found", &["<*>"], index_html_response(), ResponseVerificationError::InvalidExpressionPath)]
+    #[case::redirect_for_old_trailing_slash_path(&"/old-path/", &["old-path", "<$>"], redirect_response())]
+    #[case::redirect_for_index_html_path(&"/", &["old-path", "<$>"], redirect_response())]
+    #[case::redirect_for_not_found_path(&"/not-found", &["old-path", "<$>"], redirect_response())]
+    #[case::redirect_for_nested_not_found_path(&"/not/found", &["old-path", "<$>"], redirect_response())]
+    #[case::redirect_for_js_path(&"/js/index.js", &["<*>"], index_html_response())]
+    #[case::redirect_for_js_not_found_path(&"/js/not-found", &["<*>"], index_html_response())]
+    #[case::redirect_for_js_nested_not_found_path(&"/js/not/found", &["<*>"], index_html_response())]
     // assert that encoded responses are accepted for the incorrect paths
-    #[case::identity_encoding_for_encoded_trailing_slash_path(&"/multi-encoded-path/", &["multi-encoded-path", "<$>"], content_encoding_identity_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::gzip_encoding_for_encoded_trailing_slash_path(&"/multi-encoded-path/", &["multi-encoded-path", "<$>"], content_encoding_gzip_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::deflate_encoding_for_encoded_trailing_slash_path(&"/multi-encoded-path/", &["multi-encoded-path", "<$>"], content_encoding_deflate_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::identity_encoding_for_index_html_path(&"/", &["multi-encoded-path", "<$>"], content_encoding_identity_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::gzip_encoding_for_not_found_path(&"/not-found", &["multi-encoded-path", "<$>"], content_encoding_gzip_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::gzip_encoding_for_nested_not_found_path(&"/not/found", &["multi-encoded-path", "<$>"], content_encoding_gzip_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::deflate_encoding_for_js_path(&"/js/index.js", &["multi-encoded-path", "<$>"], content_encoding_deflate_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::deflate_encoding_for_js_not_found_path(&"/js/not-found", &["multi-encoded-path", "<$>"], content_encoding_deflate_response(), ResponseVerificationError::InvalidExpressionPath)]
-    #[case::deflate_encoding_for_nested_js_not_found_path(&"/js/not/found", &["multi-encoded-path", "<$>"], content_encoding_deflate_response(), ResponseVerificationError::InvalidExpressionPath)]
+    #[case::identity_encoding_for_encoded_trailing_slash_path(&"/multi-encoded-path/", &["multi-encoded-path", "<$>"], content_encoding_identity_response())]
+    #[case::gzip_encoding_for_encoded_trailing_slash_path(&"/multi-encoded-path/", &["multi-encoded-path", "<$>"], content_encoding_gzip_response())]
+    #[case::deflate_encoding_for_encoded_trailing_slash_path(&"/multi-encoded-path/", &["multi-encoded-path", "<$>"], content_encoding_deflate_response())]
+    #[case::identity_encoding_for_index_html_path(&"/", &["multi-encoded-path", "<$>"], content_encoding_identity_response())]
+    #[case::gzip_encoding_for_not_found_path(&"/not-found", &["multi-encoded-path", "<$>"], content_encoding_gzip_response())]
+    #[case::gzip_encoding_for_nested_not_found_path(&"/not/found", &["multi-encoded-path", "<$>"], content_encoding_gzip_response())]
+    #[case::deflate_encoding_for_js_path(&"/js/index.js", &["multi-encoded-path", "<$>"], content_encoding_deflate_response())]
+    #[case::deflate_encoding_for_js_not_found_path(&"/js/not-found", &["multi-encoded-path", "<$>"], content_encoding_deflate_response())]
+    #[case::deflate_encoding_for_nested_js_not_found_path(&"/js/not/found", &["multi-encoded-path", "<$>"], content_encoding_deflate_response())]
     fn certification_scenarios_fail_verification(
         #[from(certificate_tree)] expr_tree: ExprTree,
         #[case] req_path: &str,
         #[case] expr_path: &[&str],
         #[case] mut expected_response: Response,
-        #[case] expected_failure: ResponseVerificationError,
     ) {
         let request = Request {
             url: req_path.into(),
@@ -179,18 +178,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                ref reason,
-            } if verification_version == 2 && match (reason, expected_failure) {
-                (ResponseVerificationError::InvalidExpressionPath, ResponseVerificationError::InvalidExpressionPath) => true,
-                _ => false
-            }
+            Err(ResponseVerificationError::InvalidExpressionPath)
         ));
     }
 
@@ -252,7 +244,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 2 && response == Some(expected_certified_response)
@@ -291,15 +283,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidResponseHashes)
+            Err(ResponseVerificationError::InvalidResponseHashes)
         ));
     }
 }

--- a/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
@@ -2,9 +2,7 @@
 mod tests {
     use ic_response_verification::cel::cel_to_certification;
     use ic_response_verification::hash::{request_hash, response_hash};
-    use ic_response_verification::types::{
-        Request, Response, VerificationResult, VerifiedResponse,
-    };
+    use ic_response_verification::types::{Request, Response, VerificationInfo, VerifiedResponse};
     use ic_response_verification::verify_request_response_pair;
     use ic_response_verification_test_utils::{
         create_v2_fixture, get_current_timestamp, remove_whitespace, V2Fixture,
@@ -67,7 +65,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 2 && response.is_none()
@@ -151,7 +149,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 2 && response == Some(expected_response)
@@ -243,7 +241,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 2 && response == Some(expected_response)
@@ -333,7 +331,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            VerificationResult::Passed {
+            VerificationInfo {
                 verification_version,
                 response,
             } if verification_version == 2 && response == Some(expected_response)

--- a/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
@@ -8,7 +8,7 @@ mod tests {
     use ic_response_verification::{
         cel::cel_to_certification,
         hash::{request_hash, response_hash},
-        types::{Request, Response, VerificationResult},
+        types::{Request, Response},
         verify_request_response_pair, ResponseVerificationError,
     };
     use ic_response_verification_test_utils::{
@@ -73,15 +73,11 @@ mod tests {
             fixtures::MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             fixtures::MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidResponseHashes)
+            Err(ResponseVerificationError::InvalidResponseHashes)
         ));
     }
 
@@ -142,15 +138,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidResponseHashes)
+            Err(ResponseVerificationError::InvalidResponseHashes)
         ));
     }
 
@@ -216,15 +208,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidExpressionPath)
+            Err(ResponseVerificationError::InvalidExpressionPath)
         ));
     }
 
@@ -295,15 +283,11 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
         assert!(matches!(
             result,
-            VerificationResult::Failed {
-                verification_version,
-                reason,
-            } if verification_version == 2 && matches!(reason, ResponseVerificationError::InvalidExpressionPath)
+            Err(ResponseVerificationError::InvalidExpressionPath)
         ));
     }
 
@@ -368,19 +352,17 @@ mod tests {
             MAX_CERT_TIME_OFFSET_NS,
             &root_key,
             MIN_REQUESTED_VERIFICATION_VERSION,
-        )
-        .unwrap();
+        );
 
-        assert!(matches!(result, VerificationResult::Failed {
-            verification_version,
-            ref reason,
-        } if verification_version == 2 && match (reason, expected_failure) {
-            (ResponseVerificationError::CertificateVerificationFailed, ResponseVerificationError::CertificateVerificationFailed) => true,
-            (ResponseVerificationError::CertificatePrincipalOutOfRange, ResponseVerificationError::CertificatePrincipalOutOfRange) => true,
-            (ResponseVerificationError::CertificateTimeTooFarInThePast { .. }, ResponseVerificationError::CertificateTimeTooFarInThePast { .. }) => true,
-            (ResponseVerificationError::CertificateTimeTooFarInTheFuture { .. }, ResponseVerificationError::CertificateTimeTooFarInTheFuture { .. }) => true,
-            _ => false
-        }))
+        assert!(
+            matches!(result, Err(ref failure) if match (failure, expected_failure) {
+                (ResponseVerificationError::CertificateVerificationFailed, ResponseVerificationError::CertificateVerificationFailed) => true,
+                (ResponseVerificationError::CertificatePrincipalOutOfRange, ResponseVerificationError::CertificatePrincipalOutOfRange) => true,
+                (ResponseVerificationError::CertificateTimeTooFarInThePast { .. }, ResponseVerificationError::CertificateTimeTooFarInThePast { .. }) => true,
+                (ResponseVerificationError::CertificateTimeTooFarInTheFuture { .. }, ResponseVerificationError::CertificateTimeTooFarInTheFuture { .. }) => true,
+                _ => false
+            })
+        )
     }
 }
 


### PR DESCRIPTION
This PR updates the return type to always be a result/exception, instead of only for "unexpected" scenarios.
There are also some Cargo clippy fixes and a fix for the e2e tests that allowed broken e2e tests to pass in a previous PR: https://github.com/dfinity/response-verification/actions/runs/5737416933/job/15549030697

