### PR TITLE
feat: add ic-certification library

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -8,6 +8,7 @@ commitizen:
     - packages/certificate-verification-js/package.json:version
     - packages/ic-cbor/Cargo.toml:version
     - packages/ic-certificate-verification/Cargo.toml:version
+    - packages/ic-certification/Cargo.toml:version
     - packages/ic-certification-testing/Cargo.toml:version
     - packages/ic-certification-testing-wasm/Cargo.toml:version
     - packages/ic-certification-testing-wasm/package.json:version

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -67,6 +67,7 @@ jobs:
             packages/certificate-verification-js/package.json
             packages/ic-cbor/Cargo.toml
             packages/ic-certificate-verification/Cargo.toml
+            packages/ic-certification/Cargo.toml
             packages/ic-certification-testing/Cargo.toml
             packages/ic-certification-testing-wasm/Cargo.lock
             packages/ic-certification-testing-wasm/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
+      - name: Release ic-certification Cargo crate
+        run: cargo publish -p ic-certification --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
       - name: Release ic-response-verification Cargo crate
         run: cargo publish -p ic-response-verification --token ${CRATES_TOKEN}
         env:
@@ -78,6 +83,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: >
+            target/package/ic-certification-${{ github.ref_name }}.crate,
             target/package/ic-representation-independent-hash-${{ github.ref_name }}.crate,
             target/package/ic-cbor-${{ github.ref_name }}.crate,
             target/package/ic-certificate-verification-${{ github.ref_name }}.crate,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,7 @@ dependencies = [
  "hex",
  "http",
  "http-body",
- "ic-certification",
+ "ic-certification 0.26.1",
  "ic-verify-bls-signature",
  "k256",
  "leb128",
@@ -1220,7 +1220,7 @@ name = "ic-cbor"
 version = "1.1.0"
 dependencies = [
  "candid 0.9.1",
- "ic-certification",
+ "ic-certification 1.1.0",
  "ic-response-verification-test-utils",
  "leb128",
  "nom",
@@ -1233,7 +1233,7 @@ version = "1.1.0"
 dependencies = [
  "candid 0.9.1",
  "ic-cbor",
- "ic-certification",
+ "ic-certification 1.1.0",
  "ic-certification-testing",
  "ic-response-verification-test-utils",
  "leb128",
@@ -1251,6 +1251,17 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "ic-certification"
+version = "1.1.0"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
  "sha2 0.10.6",
 ]
 
@@ -1492,7 +1503,7 @@ dependencies = [
  "http",
  "ic-cbor",
  "ic-certificate-verification",
- "ic-certification",
+ "ic-certification 1.1.0",
  "ic-certification-testing",
  "ic-certified-map",
  "ic-crypto-tree-hash",
@@ -1520,7 +1531,7 @@ dependencies = [
  "base64 0.21.2",
  "flate2",
  "hex",
- "ic-certification",
+ "ic-certification 1.1.0",
  "ic-certification-testing",
  "ic-certified-map",
  "ic-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "examples/rust",
     "packages/ic-cbor",
+    "packages/ic-certification",
     "packages/ic-certificate-verification",
     "packages/ic-certification-testing",
     "packages/ic-representation-independent-hash",

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ This package encapsulates the protocol for such verification. It is used by [the
 | `pnpm run -F @dfinity/certificate-verification build` | Build NPM package |
 | `pnpm run -F @dfinity/certificate-verification test`  | Test NPM package  |
 
+### Certification
+
+- [Cargo crate](./packages/ic-certification/README.md)
+
+| Command                                          | Description            |
+| ------------------------------------------------ | ---------------------- |
+| `cargo build -p ic-certification`                | Build Cargo crate      |
+| `cargo test -p ic-certification`                 | Test Cargo crate       |
+| `cargo doc -p ic-certification --no-deps --open` | Build Cargo crate docs |
+
 ### Certification Testing
 
 - [NPM package](./packages/ic-certification-testing-wasm/README.md)

--- a/packages/ic-cbor/Cargo.toml
+++ b/packages/ic-cbor/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "README.md"]
 [dependencies]
 candid = "0.9"
 nom = "7.1"
-ic-certification = { version = "0.26", default_features = false }
+ic-certification = { path = "../ic-certification", version = "1.1.0", default_features = false }
 thiserror = "1.0"
 leb128 = "0.2"
 

--- a/packages/ic-certificate-verification/Cargo.toml
+++ b/packages/ic-certificate-verification/Cargo.toml
@@ -22,7 +22,7 @@ include = ["src", "Cargo.toml", "README.md"]
 [dependencies]
 candid = "0.9"
 nom = "7.1"
-ic-certification = { version = "0.26", default_features = false }
+ic-certification = { path = "../ic-certification", version = "1.1.0", default_features = false }
 ic-cbor = { path = "../ic-cbor", version = "1.1.0" }
 miracl_core_bls12381 = { version = "4.2", default_features = false, features = [
     "std",

--- a/packages/ic-certification/Cargo.toml
+++ b/packages/ic-certification/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ic-certification"
+description = "Types related to the Internet Computer Public Specification."
+version = "1.1.0"
+authors = ["DFINITY Stiftung"]
+license = "Apache-2.0"
+readme = "README.md"
+documentation = "https://docs.rs/ic-certification"
+homepage = "https://github.com/dfinity/response-verification#readme"
+repository = "https://github.com/dfinity/response-verification"
+categories = ["api-bindings", "data-structures", "no-std"]
+keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
+edition = "2021"
+include = ["src", "Cargo.toml", "LICENSE", "README.md"]
+
+[dependencies]
+hex = "0.4"
+sha2 = "0.10"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_bytes = { version = "0.11", optional = true }
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_cbor = "0.11"
+
+[features]
+default = ['serde', 'serde_bytes']

--- a/packages/ic-certification/LICENSE
+++ b/packages/ic-certification/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 DFINITY Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ic-certification/README.md
+++ b/packages/ic-certification/README.md
@@ -1,0 +1,6 @@
+# IC Certification
+
+A collection of types related to the Internet Computer Protocol.
+
+If you need support for the serde library, you will need to use the `serde` feature
+(available by default).

--- a/packages/ic-certification/src/certificate.rs
+++ b/packages/ic-certification/src/certificate.rs
@@ -1,0 +1,334 @@
+use crate::hash_tree::HashTree;
+
+/// A `Certificate` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certificate>
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(serialize = "Storage: serde_bytes::Serialize"))
+)]
+pub struct Certificate<Storage: AsRef<[u8]>> {
+    /// The hash tree.
+    pub tree: HashTree<Storage>,
+
+    /// The signature of the root hash in `tree`.
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+    pub signature: Storage,
+
+    /// A delegation from the root key to the key used to sign `signature`, if one exists.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub delegation: Option<Delegation<Storage>>,
+}
+
+/// A `Delegation` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certification-delegation>
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(serialize = "Storage: serde_bytes::Serialize"))
+)]
+pub struct Delegation<Storage: AsRef<[u8]>> {
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+    pub subnet_id: Storage,
+
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+    pub certificate: Storage,
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::{Certificate, Delegation};
+    use crate::{hash_tree::HashTreeNode, serde_impl::*};
+
+    use std::{borrow::Cow, fmt, marker::PhantomData};
+
+    use serde::{
+        de::{self, MapAccess, SeqAccess, Visitor},
+        Deserialize, Deserializer,
+    };
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "snake_case")]
+    enum CertificateField {
+        Tree,
+        Signature,
+        Delegation,
+    }
+    struct CertificateVisitor<S>(PhantomData<S>);
+
+    impl<'de, S: Storage> Visitor<'de> for CertificateVisitor<S>
+    where
+        Delegation<S::Value<'de>>: Deserialize<'de>,
+        HashTreeNode<S::Value<'de>>: Deserialize<'de>,
+    {
+        type Value = Certificate<S::Value<'de>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("struct Delegation")
+        }
+
+        fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+        where
+            V: SeqAccess<'de>,
+        {
+            let tree = seq
+                .next_element()?
+                .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+            let signature = S::convert(
+                seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?,
+            );
+            let delegation = seq.next_element()?;
+
+            Ok(Certificate {
+                tree,
+                signature,
+                delegation,
+            })
+        }
+
+        fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut tree = None;
+            let mut signature = None;
+            let mut delegation = None;
+            while let Some(key) = map.next_key()? {
+                match key {
+                    CertificateField::Tree => {
+                        if tree.is_some() {
+                            return Err(de::Error::duplicate_field("tree"));
+                        }
+                        tree = Some(map.next_value()?);
+                    }
+                    CertificateField::Signature => {
+                        if signature.is_some() {
+                            return Err(de::Error::duplicate_field("signature"));
+                        }
+                        signature = Some(map.next_value()?);
+                    }
+                    CertificateField::Delegation => {
+                        if delegation.is_some() {
+                            return Err(de::Error::duplicate_field("signature"));
+                        }
+                        delegation = Some(map.next_value()?);
+                    }
+                }
+            }
+            let tree = tree.ok_or_else(|| de::Error::missing_field("tree"))?;
+            let signature =
+                S::convert(signature.ok_or_else(|| de::Error::missing_field("signature"))?);
+            Ok(Certificate {
+                tree,
+                signature,
+                delegation,
+            })
+        }
+    }
+
+    fn deserialize_certificate<'de, S: Storage, D>(
+        deserializer: D,
+    ) -> Result<Certificate<S::Value<'de>>, D::Error>
+    where
+        Delegation<S::Value<'de>>: Deserialize<'de>,
+        HashTreeNode<S::Value<'de>>: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tree", "signature", "delegation"];
+        deserializer.deserialize_struct("Certificate", FIELDS, CertificateVisitor::<S>(PhantomData))
+    }
+
+    impl<'de> Deserialize<'de> for Certificate<Vec<u8>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_certificate::<VecStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Certificate<&'de [u8]> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_certificate::<SliceStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Certificate<Cow<'de, [u8]>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_certificate::<CowStorage, _>(deserializer)
+        }
+    }
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "snake_case")]
+    enum DelegationField {
+        SubnetId,
+        Certificate,
+    }
+    struct DelegationVisitor<S>(PhantomData<S>);
+
+    impl<'de, S: Storage> Visitor<'de> for DelegationVisitor<S> {
+        type Value = Delegation<S::Value<'de>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("struct Delegation")
+        }
+
+        fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+        where
+            V: SeqAccess<'de>,
+        {
+            let subnet_id = S::convert(
+                seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?,
+            );
+            let certificate = S::convert(
+                seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?,
+            );
+            Ok(Delegation {
+                subnet_id,
+                certificate,
+            })
+        }
+
+        fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut subnet_id = None;
+            let mut certificate = None;
+            while let Some(key) = map.next_key()? {
+                match key {
+                    DelegationField::SubnetId => {
+                        if subnet_id.is_some() {
+                            return Err(de::Error::duplicate_field("subnet_id"));
+                        }
+                        subnet_id = Some(map.next_value()?);
+                    }
+                    DelegationField::Certificate => {
+                        if certificate.is_some() {
+                            return Err(de::Error::duplicate_field("certificate"));
+                        }
+                        certificate = Some(map.next_value()?);
+                    }
+                }
+            }
+            let subnet_id =
+                S::convert(subnet_id.ok_or_else(|| de::Error::missing_field("subnet_id"))?);
+            let certificate =
+                S::convert(certificate.ok_or_else(|| de::Error::missing_field("certificate"))?);
+            Ok(Delegation {
+                subnet_id,
+                certificate,
+            })
+        }
+    }
+
+    fn deserialize_delegation<'de, S: Storage, D>(
+        deserializer: D,
+    ) -> Result<Delegation<S::Value<'de>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["subnet_id", "certificate"];
+        deserializer.deserialize_struct("Delegation", FIELDS, DelegationVisitor::<S>(PhantomData))
+    }
+
+    impl<'de> Deserialize<'de> for Delegation<Vec<u8>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_delegation::<VecStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Delegation<&'de [u8]> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_delegation::<SliceStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Delegation<Cow<'de, [u8]>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_delegation::<CowStorage, _>(deserializer)
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod tests {
+    use super::*;
+    use crate::hash_tree::{empty, fork, label, leaf};
+
+    fn create_tree() -> HashTree<Vec<u8>> {
+        fork(
+            fork(
+                label(
+                    "a",
+                    fork(
+                        fork(label("x", leaf(*b"hello")), empty()),
+                        label("y", leaf(*b"world")),
+                    ),
+                ),
+                label("b", leaf(*b"good")),
+            ),
+            fork(label("c", empty()), label("d", leaf(*b"morning"))),
+        )
+    }
+
+    #[test]
+    fn serialize_to_cbor() {
+        let tree = create_tree();
+        let signature = vec![1, 2, 3, 4, 5, 6];
+
+        let certificate = Certificate {
+            tree,
+            signature,
+            delegation: None,
+        };
+
+        let cbor_bytes =
+            serde_cbor::to_vec(&certificate).expect("Failed to encode certificate to cbor");
+        let cbor_hex = hex::encode(cbor_bytes);
+
+        assert_eq!(cbor_hex, "a264747265658301830183024161830183018302417882034568656c6c6f810083024179820345776f726c6483024162820344676f6f648301830241638100830241648203476d6f726e696e67697369676e617475726546010203040506");
+    }
+
+    #[test]
+    fn serialize_to_cbor_with_delegation() {
+        let tree = create_tree();
+        let signature = vec![1, 2, 3, 4, 5, 6];
+        let delegation = Delegation {
+            subnet_id: vec![7, 8, 9, 10, 11, 12],
+            certificate: vec![13, 14, 15, 16, 17, 18],
+        };
+
+        let certificate = Certificate {
+            tree,
+            signature,
+            delegation: Some(delegation),
+        };
+
+        let cbor_bytes =
+            serde_cbor::to_vec(&certificate).expect("Failed to encode certificate to cbor");
+        let cbor_hex = hex::encode(cbor_bytes);
+
+        assert_eq!(cbor_hex, "a364747265658301830183024161830183018302417882034568656c6c6f810083024179820345776f726c6483024162820344676f6f648301830241638100830241648203476d6f726e696e67697369676e6174757265460102030405066a64656c65676174696f6ea2697375626e65745f6964460708090a0b0c6b6365727469666963617465460d0e0f101112");
+    }
+}

--- a/packages/ic-certification/src/hash_tree/mod.rs
+++ b/packages/ic-certification/src/hash_tree/mod.rs
@@ -1,0 +1,785 @@
+//! cf <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certification-encoding>
+
+use hex::FromHexError;
+use sha2::Digest;
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+};
+
+/// Sha256 Digest: 32 bytes
+pub type Sha256Digest = [u8; 32];
+
+#[derive(Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+/// For labeled [HashTreeNode]
+pub struct Label<Storage: AsRef<[u8]>>(Storage);
+
+impl<Storage: AsRef<[u8]>> Label<Storage> {
+    /// Create a label from bytes.
+    pub fn from_bytes<'a>(v: &'a [u8]) -> Self
+    where
+        &'a [u8]: Into<Storage>,
+    {
+        Self(v.into())
+    }
+
+    /// Convert labels
+    pub fn from_label<StorageB: AsRef<[u8]> + Into<Storage>>(s: Label<StorageB>) -> Self {
+        Self(s.0.into())
+    }
+
+    /// Returns this label as bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+
+    /// The length of the output of [`Self::write_hex`]
+    fn hex_len(&self) -> usize {
+        self.as_bytes().len() * 2
+    }
+
+    /// Write out the hex
+    fn write_hex(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        self.as_bytes()
+            .iter()
+            .try_for_each(|b| write!(f, "{:02X}", b))
+    }
+}
+
+impl<Storage: AsRef<[u8]>> From<Storage> for Label<Storage> {
+    fn from(s: Storage) -> Self {
+        Self(s)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Label<Vec<u8>> {
+    fn from(s: [u8; N]) -> Self {
+        Self(s.into())
+    }
+}
+impl<'a, const N: usize> From<&'a [u8; N]> for Label<Vec<u8>> {
+    fn from(s: &'a [u8; N]) -> Self {
+        Self(s.as_slice().into())
+    }
+}
+impl<'a> From<&'a [u8]> for Label<Vec<u8>> {
+    fn from(s: &'a [u8]) -> Self {
+        Self(s.into())
+    }
+}
+impl<'a> From<&'a str> for Label<Vec<u8>> {
+    fn from(s: &'a str) -> Self {
+        Self(s.as_bytes().into())
+    }
+}
+impl From<String> for Label<Vec<u8>> {
+    fn from(s: String) -> Self {
+        Self(s.into())
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for Label<&'a [u8]> {
+    fn from(s: &'a [u8; N]) -> Self {
+        Self(s.as_slice())
+    }
+}
+impl<'a> From<&'a str> for Label<&'a [u8]> {
+    fn from(s: &'a str) -> Self {
+        Self(s.as_bytes())
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for Label<Cow<'a, [u8]>> {
+    fn from(s: &'a [u8; N]) -> Self {
+        Self(s.as_slice().into())
+    }
+}
+impl<'a> From<&'a [u8]> for Label<Cow<'a, [u8]>> {
+    fn from(s: &'a [u8]) -> Self {
+        Self(s.into())
+    }
+}
+impl<'a> From<&'a str> for Label<Cow<'a, [u8]>> {
+    fn from(s: &'a str) -> Self {
+        Self(s.as_bytes().into())
+    }
+}
+
+impl<Storage: AsRef<[u8]>> fmt::Display for Label<Storage> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use fmt::Write;
+
+        // Try to print it as an UTF-8 string. If an error happens, print the bytes
+        // as hexadecimal.
+        match std::str::from_utf8(self.as_bytes()) {
+            Ok(s) if s.chars().all(|c| c.is_ascii_graphic()) => {
+                f.write_char('"')?;
+                f.write_str(s)?;
+                f.write_char('"')
+            }
+            _ => {
+                write!(f, "0x")?;
+                fmt::Debug::fmt(self, f)
+            }
+        }
+    }
+}
+
+impl<Storage: AsRef<[u8]>> fmt::Debug for Label<Storage> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write_hex(f)
+    }
+}
+
+impl<Storage: AsRef<[u8]>> AsRef<[u8]> for Label<Storage> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+/// A result of looking up for a certificate.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum LookupResult<'tree> {
+    /// The value is guaranteed to be absent in the original state tree.
+    Absent,
+
+    /// This partial view does not include information about this path, and the original
+    /// tree may or may note include this value.
+    Unknown,
+
+    /// The value was found at the referenced node.
+    Found(&'tree [u8]),
+
+    /// The path does not make sense for this certificate.
+    Error,
+}
+
+/// A result of looking up for a subtree.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum SubtreeLookupResult<Storage: AsRef<[u8]>> {
+    /// The subtree at the provided path is guaranteed to be absent in the original state tree.
+    Absent,
+
+    /// This partial view does not include information about this path, and the original
+    /// tree may or may note include a subtree at this path.
+    Unknown,
+
+    /// The subtree was found at the provided path.
+    Found(HashTree<Storage>),
+}
+
+/// A HashTree representing a full tree.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HashTree<Storage: AsRef<[u8]>> {
+    root: HashTreeNode<Storage>,
+}
+
+impl<Storage: AsRef<[u8]>> fmt::Debug for HashTree<Storage> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashTree")
+            .field("root", &self.root)
+            .finish()
+    }
+}
+
+#[allow(dead_code)]
+impl<Storage: AsRef<[u8]>> HashTree<Storage> {
+    /// Recomputes root hash of the full tree that this hash tree was constructed from.
+    #[inline]
+    pub fn digest(&self) -> Sha256Digest {
+        self.root.digest()
+    }
+
+    /// Given a (verified) tree, the client can fetch the value at a given path, which is a
+    /// sequence of labels (blobs).
+    pub fn lookup_path<P>(&self, path: P) -> LookupResult<'_>
+    where
+        P: IntoIterator,
+        P::Item: AsRef<[u8]>,
+    {
+        self.root.lookup_path(&mut path.into_iter())
+    }
+}
+
+impl<Storage: Clone + AsRef<[u8]>> HashTree<Storage> {
+    /// Given a (verified) tree, the client can fetch the subtree at a given path, which is a
+    /// sequence of labels (blobs).
+    pub fn lookup_subtree<'p, P, I>(&self, path: P) -> SubtreeLookupResult<Storage>
+    where
+        P: IntoIterator<Item = &'p I>,
+        I: ?Sized + AsRef<[u8]> + 'p,
+    {
+        self.root
+            .lookup_subtree(&mut path.into_iter().map(|v| v.borrow()))
+    }
+
+    /// List all paths in the [HashTree]
+    pub fn list_paths(&self) -> Vec<Vec<Label<Storage>>> {
+        self.root.list_paths(&vec![])
+    }
+}
+
+impl<Storage: AsRef<[u8]>> AsRef<HashTreeNode<Storage>> for HashTree<Storage> {
+    fn as_ref(&self) -> &HashTreeNode<Storage> {
+        &self.root
+    }
+}
+
+impl<Storage: AsRef<[u8]>> From<HashTree<Storage>> for HashTreeNode<Storage> {
+    fn from(tree: HashTree<Storage>) -> HashTreeNode<Storage> {
+        tree.root
+    }
+}
+
+/// Create an empty hash tree.
+#[inline]
+pub fn empty<Storage: AsRef<[u8]>>() -> HashTree<Storage> {
+    HashTree {
+        root: HashTreeNode::Empty(),
+    }
+}
+
+/// Create a forked tree from two trees or node.
+#[inline]
+pub fn fork<Storage: AsRef<[u8]>>(
+    left: HashTree<Storage>,
+    right: HashTree<Storage>,
+) -> HashTree<Storage> {
+    HashTree {
+        root: HashTreeNode::Fork(Box::new((left.root, right.root))),
+    }
+}
+
+/// Create a labeled hash tree.
+#[inline]
+pub fn label<Storage: AsRef<[u8]>, L: Into<Label<Storage>>, N: Into<HashTree<Storage>>>(
+    label: L,
+    node: N,
+) -> HashTree<Storage> {
+    HashTree {
+        root: HashTreeNode::Labeled(label.into(), Box::new(node.into().root)),
+    }
+}
+
+/// Create a leaf in the tree.
+#[inline]
+pub fn leaf<Storage: AsRef<[u8]>, L: Into<Storage>>(leaf: L) -> HashTree<Storage> {
+    HashTree {
+        root: HashTreeNode::Leaf(leaf.into()),
+    }
+}
+
+/// Create a pruned tree node.
+#[inline]
+pub fn pruned<Storage: AsRef<[u8]>, C: Into<Sha256Digest>>(content: C) -> HashTree<Storage> {
+    HashTree {
+        root: HashTreeNode::Pruned(content.into()),
+    }
+}
+
+/// Create a pruned tree node, from a hex representation of the data. Useful for
+/// testing or hard coded values.
+#[inline]
+pub fn pruned_from_hex<Storage: AsRef<[u8]>, C: AsRef<str>>(
+    content: C,
+) -> Result<HashTree<Storage>, FromHexError> {
+    let mut decode: Sha256Digest = [0; 32];
+    hex::decode_to_slice(content.as_ref(), &mut decode)?;
+
+    Ok(pruned(decode))
+}
+
+/// Private type for label lookup result.
+#[derive(Debug)]
+enum LookupLabelResult<'node, Storage: AsRef<[u8]>> {
+    /// The label is not part of this node's tree.
+    Absent,
+
+    /// Same as absent, but some leaves were pruned and so it's impossible to know.
+    Unknown,
+
+    /// The label was not found, but could still be to the left.
+    Less,
+
+    /// The label was not found, but could still be to the right.
+    Greater,
+
+    /// The label was found. Contains a reference to the [HashTreeNode].
+    Found(&'node HashTreeNode<Storage>),
+}
+
+/// A Node in the HashTree.
+#[derive(Clone, PartialEq, Eq)]
+pub enum HashTreeNode<Storage: AsRef<[u8]>> {
+    Empty(),
+    Fork(Box<(Self, Self)>),
+    Labeled(Label<Storage>, Box<Self>),
+    Leaf(Storage),
+    Pruned(Sha256Digest),
+}
+
+impl<Storage: AsRef<[u8]>> fmt::Debug for HashTreeNode<Storage> {
+    // Shows a nicer view to debug than the default debugger.
+    // Example:
+    //
+    // ```
+    // HashTree {
+    //     root: Fork(
+    //         Fork(
+    //             Label("a", Fork(
+    //                 Pruned(1b4feff9bef8131788b0c9dc6dbad6e81e524249c879e9f10f71ce3749f5a638),
+    //                 Label("y", Leaf("world")),
+    //             )),
+    //             Label("b", Pruned(7b32ac0c6ba8ce35ac82c255fc7906f7fc130dab2a090f80fe12f9c2cae83ba6)),
+    //         ),
+    //         Fork(
+    //             Pruned(ec8324b8a1f1ac16bd2e806edba78006479c9877fed4eb464a25485465af601d),
+    //             Label("d", Leaf("morning")),
+    //         ),
+    //     ),
+    // }
+    // ```
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn readable_print(f: &mut fmt::Formatter<'_>, v: &[u8]) -> fmt::Result {
+            // If it's UTF-8 and all the characters are graphic ASCII, then show as a string.
+            // If it's short, show hex.
+            // Otherwise, show length.
+            match std::str::from_utf8(v) {
+                Ok(s) if s.chars().all(|c| c.is_ascii_graphic()) => {
+                    f.write_str("\"")?;
+                    f.write_str(s)?;
+                    f.write_str("\"")
+                }
+                _ if v.len() <= 32 => {
+                    f.write_str("0x")?;
+                    f.write_str(&hex::encode(v))
+                }
+                _ => {
+                    write!(f, "{} bytes", v.len())
+                }
+            }
+        }
+
+        match self {
+            HashTreeNode::Empty() => f.write_str("Empty"),
+            HashTreeNode::Fork(nodes) => f
+                .debug_tuple("Fork")
+                .field(&nodes.0)
+                .field(&nodes.1)
+                .finish(),
+            HashTreeNode::Leaf(v) => {
+                f.write_str("Leaf(")?;
+                readable_print(f, v.as_ref())?;
+                f.write_str(")")
+            }
+            HashTreeNode::Labeled(l, node) => {
+                f.write_str("Label(")?;
+                readable_print(f, l.as_bytes())?;
+                f.write_str(", ")?;
+                node.fmt(f)?;
+                f.write_str(")")
+            }
+            HashTreeNode::Pruned(digest) => write!(f, "Pruned({})", hex::encode(digest.as_ref())),
+        }
+    }
+}
+
+impl<Storage: AsRef<[u8]>> HashTreeNode<Storage> {
+    /// Update a hasher with the domain separator (byte(|s|) . s).
+    #[inline]
+    fn domain_sep(&self, hasher: &mut sha2::Sha256) {
+        let domain_sep = match self {
+            HashTreeNode::Empty() => "ic-hashtree-empty",
+            HashTreeNode::Fork(_) => "ic-hashtree-fork",
+            HashTreeNode::Labeled(_, _) => "ic-hashtree-labeled",
+            HashTreeNode::Leaf(_) => "ic-hashtree-leaf",
+            HashTreeNode::Pruned(_) => return,
+        };
+        hasher.update([domain_sep.len() as u8]);
+        hasher.update(domain_sep.as_bytes());
+    }
+
+    /// Calculate the digest of this node only.
+    #[inline]
+    pub fn digest(&self) -> Sha256Digest {
+        let mut hasher = sha2::Sha256::new();
+        self.domain_sep(&mut hasher);
+
+        match self {
+            HashTreeNode::Empty() => {}
+            HashTreeNode::Fork(nodes) => {
+                hasher.update(nodes.0.digest());
+                hasher.update(nodes.1.digest());
+            }
+            HashTreeNode::Labeled(label, node) => {
+                hasher.update(label.as_bytes());
+                hasher.update(node.digest());
+            }
+            HashTreeNode::Leaf(bytes) => {
+                hasher.update(bytes.as_ref());
+            }
+            HashTreeNode::Pruned(digest) => {
+                return *digest;
+            }
+        }
+
+        hasher.finalize().into()
+    }
+
+    /// Lookup a single label, returning a reference to the labeled [HashTreeNode] node if found.
+    ///
+    /// This assumes a sorted hash tree, which is what the spec says the system should
+    /// return. It will stop when it finds a label that's greater than the one being looked
+    /// for.
+    ///
+    /// This function is implemented with flattening in mind, ie. flattening the forks
+    /// is not necessary.
+    fn lookup_label(&self, label: &[u8]) -> LookupLabelResult<Storage> {
+        match self {
+            // If this node is a labeled node, check for the name.
+            HashTreeNode::Labeled(l, node) => match label.cmp(l.as_bytes()) {
+                std::cmp::Ordering::Greater => LookupLabelResult::Greater,
+                std::cmp::Ordering::Equal => LookupLabelResult::Found(node.as_ref()),
+                // If this node has a smaller label than the one we're looking for, shortcut
+                // out of this search (sorted tree), we looked too far.
+                std::cmp::Ordering::Less => LookupLabelResult::Less,
+            },
+            HashTreeNode::Fork(nodes) => {
+                let left_label = nodes.0.lookup_label(label);
+                match left_label {
+                    // On greater or unknown, look on the right side of the fork.
+                    LookupLabelResult::Greater => {
+                        let right_label = nodes.1.lookup_label(label);
+                        match right_label {
+                            LookupLabelResult::Less => LookupLabelResult::Absent,
+                            result => result,
+                        }
+                    }
+                    LookupLabelResult::Unknown => {
+                        let right_label = nodes.1.lookup_label(label);
+                        match right_label {
+                            LookupLabelResult::Less => LookupLabelResult::Unknown,
+                            result => result,
+                        }
+                    }
+                    result => result,
+                }
+            }
+            HashTreeNode::Pruned(_) => LookupLabelResult::Unknown,
+            // Any other type of node and we need to look for more forks.
+            _ => LookupLabelResult::Absent,
+        }
+    }
+
+    /// Lookup the path for the current node only. If the node does not contain the label,
+    /// this will return [None], signifying that whatever process is recursively walking the
+    /// tree should continue with siblings of this node (if possible). If it returns
+    /// [Some] value, then it found an actual result and this may be propagated to the
+    /// original process doing the lookup.
+    ///
+    /// This assumes a sorted hash tree, which is what the spec says the system should return.
+    /// It will stop when it finds a label that's greater than the one being looked for.
+    fn lookup_path(&self, path: &mut dyn Iterator<Item = impl AsRef<[u8]>>) -> LookupResult<'_> {
+        use HashTreeNode::*;
+        use LookupLabelResult as LLR;
+        use LookupResult::*;
+
+        match (
+            path.next()
+                .map(|segment| self.lookup_label(segment.as_ref())),
+            self,
+        ) {
+            (Some(LLR::Found(node)), _) => node.lookup_path(path),
+            (None, Leaf(v)) => Found(v.as_ref()),
+
+            (None, Empty()) => Absent,
+            (None, Pruned(_)) => Unknown,
+            (None, Labeled(_, _) | Fork(_)) => Error,
+
+            (Some(LLR::Unknown), _) => Unknown,
+            (Some(LLR::Absent | LLR::Greater | LLR::Less), _) => Absent,
+        }
+    }
+}
+
+impl<Storage: Clone + AsRef<[u8]>> HashTreeNode<Storage> {
+    /// Lookup a subtree at the provided path.
+    /// If the tree definitely does not contain the label, this will return [SubtreeLookupResult::Absent].
+    /// If the tree has pruned sections that might contain the path, this will return [SubtreeLookupResult::Unknown].
+    /// If the provided path is found, this will return [SubtreeLookupResult::Found] with the node that was found at that path.
+    ///
+    /// This assumes a sorted hash tree, which is what the spec says the system should return.
+    /// It will stop when it finds a label that's greater than the one being looked for.
+    fn lookup_subtree(
+        &self,
+        path: &mut dyn Iterator<Item = impl AsRef<[u8]>>,
+    ) -> SubtreeLookupResult<Storage> {
+        use LookupLabelResult as LLR;
+        use SubtreeLookupResult::*;
+
+        match path
+            .next()
+            .map(|segment| self.lookup_label(segment.as_ref()))
+        {
+            Some(LLR::Found(node)) => node.lookup_subtree(path),
+            Some(LLR::Unknown) => Unknown,
+            Some(LLR::Absent | LLR::Greater | LLR::Less) => Absent,
+            None => Found(HashTree {
+                root: self.to_owned(),
+            }),
+        }
+    }
+
+    fn list_paths(&self, path: &Vec<Label<Storage>>) -> Vec<Vec<Label<Storage>>> {
+        match self {
+            HashTreeNode::Empty() => vec![],
+            HashTreeNode::Fork(nodes) => {
+                [nodes.0.list_paths(path), nodes.1.list_paths(path)].concat()
+            }
+            HashTreeNode::Leaf(_) => vec![path.clone()],
+            HashTreeNode::Labeled(l, node) => {
+                let mut path = path.clone();
+                path.push(l.clone());
+                node.list_paths(&path)
+            }
+            HashTreeNode::Pruned(_) => vec![],
+        }
+    }
+}
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use std::{borrow::Cow, fmt, marker::PhantomData};
+
+    use crate::serde_impl::{CowStorage, SliceStorage, Storage, VecStorage};
+
+    use super::{HashTree, HashTreeNode, Label};
+
+    use serde::{
+        de::{self, SeqAccess, Visitor},
+        ser::SerializeSeq,
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
+    use serde_bytes::Bytes;
+
+    impl<Storage: AsRef<[u8]>> Serialize for Label<Storage> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            if serializer.is_human_readable() {
+                let mut s = String::with_capacity(self.hex_len());
+                self.write_hex(&mut s).unwrap();
+                s.serialize(serializer)
+            } else {
+                serializer.serialize_bytes(self.0.as_ref())
+            }
+        }
+    }
+    impl<'de, Storage: AsRef<[u8]>> Deserialize<'de> for Label<Storage>
+    where
+        Storage: serde_bytes::Deserialize<'de>,
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            serde_bytes::deserialize(deserializer).map(Self)
+        }
+    }
+
+    impl<Storage: AsRef<[u8]>> Serialize for HashTreeNode<Storage> {
+        // Serialize a `MixedHashTree` per the CDDL of the public spec.
+        // See https://docs.dfinity.systems/public/certificates.cddl
+        fn serialize<S>(
+            &self,
+            serializer: S,
+        ) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+        where
+            S: Serializer,
+        {
+            match self {
+                HashTreeNode::Empty() => {
+                    let mut seq = serializer.serialize_seq(Some(1))?;
+                    seq.serialize_element(&0u8)?;
+                    seq.end()
+                }
+                HashTreeNode::Fork(tree) => {
+                    let mut seq = serializer.serialize_seq(Some(3))?;
+                    seq.serialize_element(&1u8)?;
+                    seq.serialize_element(&tree.0)?;
+                    seq.serialize_element(&tree.1)?;
+                    seq.end()
+                }
+                HashTreeNode::Labeled(label, tree) => {
+                    let mut seq = serializer.serialize_seq(Some(3))?;
+                    seq.serialize_element(&2u8)?;
+                    seq.serialize_element(Bytes::new(label.as_bytes()))?;
+                    seq.serialize_element(&tree)?;
+                    seq.end()
+                }
+                HashTreeNode::Leaf(leaf_bytes) => {
+                    let mut seq = serializer.serialize_seq(Some(2))?;
+                    seq.serialize_element(&3u8)?;
+                    seq.serialize_element(Bytes::new(leaf_bytes.as_ref()))?;
+                    seq.end()
+                }
+                HashTreeNode::Pruned(digest) => {
+                    let mut seq = serializer.serialize_seq(Some(2))?;
+                    seq.serialize_element(&4u8)?;
+                    seq.serialize_element(Bytes::new(digest))?;
+                    seq.end()
+                }
+            }
+        }
+    }
+
+    struct HashTreeNodeVisitor<S>(PhantomData<S>);
+
+    impl<'de, S: Storage> Visitor<'de> for HashTreeNodeVisitor<S>
+    where
+        HashTreeNode<S::Value<'de>>: Deserialize<'de>,
+    {
+        type Value = HashTreeNode<S::Value<'de>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str(
+                "HashTree encoded as a sequence of the form \
+                 hash-tree ::= [0] | [1 hash-tree hash-tree] | [2 bytes hash-tree] | [3 bytes] | [4 hash]",
+            )
+        }
+
+        fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+        where
+            V: SeqAccess<'de>,
+        {
+            let tag: u8 = seq
+                .next_element()?
+                .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+
+            match tag {
+                0 => {
+                    if let Some(de::IgnoredAny) = seq.next_element()? {
+                        return Err(de::Error::invalid_length(2, &self));
+                    }
+
+                    Ok(HashTreeNode::Empty())
+                }
+                1 => {
+                    let left = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                    let right = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+
+                    if let Some(de::IgnoredAny) = seq.next_element()? {
+                        return Err(de::Error::invalid_length(4, &self));
+                    }
+
+                    Ok(HashTreeNode::Fork(Box::new((left, right))))
+                }
+                2 => {
+                    let label = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                    let subtree = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+
+                    if let Some(de::IgnoredAny) = seq.next_element()? {
+                        return Err(de::Error::invalid_length(4, &self));
+                    }
+
+                    Ok(HashTreeNode::Labeled(
+                        Label(S::convert(label)),
+                        Box::new(subtree),
+                    ))
+                }
+                3 => {
+                    let bytes = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                    if let Some(de::IgnoredAny) = seq.next_element()? {
+                        return Err(de::Error::invalid_length(3, &self));
+                    }
+
+                    Ok(HashTreeNode::Leaf(S::convert(bytes)))
+                }
+                4 => {
+                    let digest_bytes: &serde_bytes::Bytes = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                    if let Some(de::IgnoredAny) = seq.next_element()? {
+                        return Err(de::Error::invalid_length(3, &self));
+                    }
+
+                    let digest =
+                        std::convert::TryFrom::try_from(digest_bytes.as_ref()).map_err(|_| {
+                            de::Error::invalid_length(digest_bytes.len(), &"Expected digest blob")
+                        })?;
+
+                    Ok(HashTreeNode::Pruned(digest))
+                }
+                _ => Err(de::Error::custom(format!(
+                    "Unknown tag: {}, expected the tag to be one of {{0, 1, 2, 3, 4}}",
+                    tag
+                ))),
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for HashTreeNode<Vec<u8>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_seq(HashTreeNodeVisitor::<VecStorage>(PhantomData))
+        }
+    }
+
+    impl<'de> Deserialize<'de> for HashTreeNode<&'de [u8]> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_seq(HashTreeNodeVisitor::<SliceStorage>(PhantomData))
+        }
+    }
+
+    impl<'de> Deserialize<'de> for HashTreeNode<Cow<'de, [u8]>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_seq(HashTreeNodeVisitor::<CowStorage>(PhantomData))
+        }
+    }
+
+    impl<Storage: AsRef<[u8]>> serde::Serialize for HashTree<Storage> {
+        fn serialize<S>(
+            &self,
+            serializer: S,
+        ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+        where
+            S: serde::Serializer,
+        {
+            self.root.serialize(serializer)
+        }
+    }
+
+    impl<'de, Storage: AsRef<[u8]>> serde::Deserialize<'de> for HashTree<Storage>
+    where
+        HashTreeNode<Storage>: Deserialize<'de>,
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            Ok(HashTree {
+                root: HashTreeNode::deserialize(deserializer)?,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/packages/ic-certification/src/hash_tree/tests.rs
+++ b/packages/ic-certification/src/hash_tree/tests.rs
@@ -1,0 +1,508 @@
+#![cfg(test)]
+
+use crate::hash_tree::{
+    empty, fork, label, leaf, pruned, pruned_from_hex, HashTree, LookupResult, SubtreeLookupResult,
+};
+
+fn lookup_path<P: AsRef<[&'static str]>>(tree: &HashTree<Vec<u8>>, path: P) -> LookupResult {
+    tree.lookup_path(path.as_ref().iter().map(|s| s.as_bytes()))
+}
+
+fn lookup_subtree<P: AsRef<[&'static str]>>(
+    tree: &HashTree<Vec<u8>>,
+    path: P,
+) -> SubtreeLookupResult<Vec<u8>> {
+    tree.lookup_subtree(path.as_ref().iter().map(|s| s.as_bytes()))
+}
+
+#[test]
+fn works_with_simple_tree() {
+    let tree: HashTree<Vec<u8>> = fork(
+        label("label 1", empty()),
+        fork(
+            pruned(*b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"),
+            leaf([1u8, 2, 3, 4, 5, 6]),
+        ),
+    );
+
+    assert_eq!(
+        hex::encode(tree.digest()),
+        "69cf325d0f20505b261821a7e77ff72fb9a8753a7964f0b587553bfb44e72532"
+    );
+}
+
+#[test]
+fn spec_example() {
+    // This is the example straight from the spec.
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            label(
+                "a",
+                fork(
+                    fork(label("x", leaf(*b"hello")), empty()),
+                    label("y", leaf(*b"world")),
+                ),
+            ),
+            label("b", leaf(*b"good")),
+        ),
+        fork(label("c", empty()), label("d", leaf(*b"morning"))),
+    );
+
+    // Check CBOR serialization.
+    #[cfg(feature = "serde")]
+    assert_eq!(
+        hex::encode(serde_cbor::to_vec(&tree).unwrap()),
+        "8301830183024161830183018302417882034568656c6c6f810083024179820345776f726c6483024162820344676f6f648301830241638100830241648203476d6f726e696e67"
+    );
+
+    assert_eq!(
+        hex::encode(tree.digest()),
+        "eb5c5b2195e62d996b84c9bcc8259d19a83786a2f59e0878cec84c811f669aa0"
+    );
+}
+
+#[test]
+fn spec_example_pruned() {
+    // This is the example straight from the spec.
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            label(
+                "a",
+                fork(
+                    pruned_from_hex(
+                        "1b4feff9bef8131788b0c9dc6dbad6e81e524249c879e9f10f71ce3749f5a638",
+                    )
+                    .unwrap(),
+                    label("y", leaf(*b"world")),
+                ),
+            ),
+            label(
+                "b",
+                pruned_from_hex("7b32ac0c6ba8ce35ac82c255fc7906f7fc130dab2a090f80fe12f9c2cae83ba6")
+                    .unwrap(),
+            ),
+        ),
+        fork(
+            pruned_from_hex("ec8324b8a1f1ac16bd2e806edba78006479c9877fed4eb464a25485465af601d")
+                .unwrap(),
+            label("d", leaf(*b"morning")),
+        ),
+    );
+
+    assert_eq!(
+        hex::encode(tree.digest()),
+        "eb5c5b2195e62d996b84c9bcc8259d19a83786a2f59e0878cec84c811f669aa0"
+    );
+
+    assert_eq!(lookup_path(&tree, ["a", "a"]), LookupResult::Unknown);
+    assert_eq!(
+        lookup_path(&tree, ["a", "y"]),
+        LookupResult::Found(b"world")
+    );
+    assert_eq!(lookup_path(&tree, ["aa"]), LookupResult::Absent);
+    assert_eq!(lookup_path(&tree, ["ax"]), LookupResult::Absent);
+    assert_eq!(lookup_path(&tree, ["b"]), LookupResult::Unknown);
+    assert_eq!(lookup_path(&tree, ["bb"]), LookupResult::Unknown);
+    assert_eq!(lookup_path(&tree, ["d"]), LookupResult::Found(b"morning"));
+    assert_eq!(lookup_path(&tree, ["e"]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_1() {
+    let tree: HashTree<Vec<u8>> = fork(
+        label("label 1", empty()),
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 0"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 1"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_2() {
+    let tree: HashTree<Vec<u8>> = fork(
+        label("label 1", empty()),
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 0"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 1"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Absent);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_paths_3() {
+    let tree: HashTree<Vec<u8>> = fork(
+        pruned([0; 32]),
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_4() {
+    let tree: HashTree<Vec<u8>> = fork(
+        pruned([0; 32]),
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_paths_5() {
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+        label("label 7", empty()),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 7"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 8"]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_6() {
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+        label("label 7", empty()),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Absent);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 7"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 8"]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_7() {
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+        pruned([0; 32]),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_paths_8() {
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+        pruned([0; 32]),
+    );
+
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Absent);
+    assert_eq!(
+        tree.lookup_path([b"label 3"]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_subtrees_1() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        label("label 1", empty()),
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 0"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 1"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Unknown);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Absent);
+}
+
+#[test]
+fn can_lookup_subtrees_2() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        label("label 1", empty()),
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 0"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 1"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Absent);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Unknown);
+}
+
+#[test]
+fn can_lookup_subtrees_3() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        pruned([0; 32]),
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Unknown);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Absent);
+}
+
+#[test]
+fn can_lookup_subtrees_4() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        pruned([0; 32]),
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Unknown);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Unknown);
+}
+
+#[test]
+fn can_lookup_subtrees_5() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+        label("label 7", empty()),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Unknown);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 7"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 8"]), Absent);
+}
+
+#[test]
+fn can_lookup_subtrees_6() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+        label("label 7", empty()),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Absent);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Unknown);
+    assert_eq!(lookup_subtree(&tree, ["label 7"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 8"]), Absent);
+}
+
+#[test]
+fn can_lookup_subtrees_7() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+        pruned([0; 32]),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Unknown);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Unknown);
+}
+
+#[test]
+fn can_lookup_subtrees_8() {
+    use SubtreeLookupResult::*;
+
+    let tree: HashTree<Vec<u8>> = fork(
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+        pruned([0; 32]),
+    );
+
+    assert_eq!(lookup_subtree(&tree, ["label 2"]), Absent);
+    assert_eq!(
+        lookup_subtree(&tree, ["label 3"]),
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
+    );
+    assert_eq!(lookup_subtree(&tree, ["label 4"]), Absent);
+    assert_eq!(lookup_subtree(&tree, ["label 5"]), Found(empty()));
+    assert_eq!(lookup_subtree(&tree, ["label 6"]), Unknown);
+}

--- a/packages/ic-certification/src/lib.rs
+++ b/packages/ic-certification/src/lib.rs
@@ -1,0 +1,107 @@
+//! # IC Certification
+
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+use hash_tree::Sha256Digest;
+use hex::FromHexError;
+
+pub mod certificate;
+pub mod hash_tree;
+
+#[doc(inline)]
+pub use hash_tree::LookupResult;
+
+/// A HashTree representing a full tree.
+pub type HashTree = hash_tree::HashTree<Vec<u8>>;
+/// For labeled [`HashTreeNode`](hash_tree::HashTreeNode)
+pub type Label = hash_tree::Label<Vec<u8>>;
+/// A result of looking up for a subtree.
+pub type SubtreeLookupResult = hash_tree::SubtreeLookupResult<Vec<u8>>;
+
+/// A `Delegation` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certification-delegation>
+pub type Delegation = certificate::Delegation<Vec<u8>>;
+/// A `Certificate` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certificate>
+pub type Certificate = certificate::Certificate<Vec<u8>>;
+
+/// Create an empty hash tree.
+#[inline]
+pub fn empty() -> HashTree {
+    hash_tree::empty()
+}
+
+/// Create a forked tree from two trees or node.
+#[inline]
+pub fn fork(left: HashTree, right: HashTree) -> HashTree {
+    hash_tree::fork(left, right)
+}
+
+/// Create a labeled hash tree.
+#[inline]
+pub fn label<L: Into<Label>, N: Into<HashTree>>(label: L, node: N) -> HashTree {
+    hash_tree::label(label, node)
+}
+
+/// Create a leaf in the tree.
+#[inline]
+pub fn leaf<L: Into<Vec<u8>>>(leaf: L) -> HashTree {
+    hash_tree::leaf(leaf)
+}
+
+/// Create a pruned tree node.
+#[inline]
+pub fn pruned<C: Into<Sha256Digest>>(content: C) -> HashTree {
+    hash_tree::pruned(content)
+}
+
+/// Create a pruned tree node, from a hex representation of the data. Useful for
+/// testing or hard coded values.
+#[inline]
+pub fn pruned_from_hex<C: AsRef<str>>(content: C) -> Result<HashTree, FromHexError> {
+    hash_tree::pruned_from_hex(content)
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use std::borrow::Cow;
+
+    use serde::Deserialize;
+    use serde_bytes::{ByteBuf, Bytes};
+
+    /// A trait to genericize deserializing owned or borrowed bytes
+    pub trait Storage {
+        type Temp<'a>: Deserialize<'a>;
+        type Value<'a>: AsRef<[u8]>;
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_>;
+    }
+
+    /// `Vec<u8>`
+    pub struct VecStorage;
+    /// `&[u8]`
+    pub struct SliceStorage;
+    /// `Cow<[u8]>`
+    pub struct CowStorage;
+
+    impl Storage for VecStorage {
+        type Temp<'a> = ByteBuf;
+        type Value<'a> = Vec<u8>;
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_> {
+            t.into_vec()
+        }
+    }
+
+    impl Storage for SliceStorage {
+        type Temp<'a> = &'a Bytes;
+        type Value<'a> = &'a [u8];
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_> {
+            t.as_ref()
+        }
+    }
+
+    impl Storage for CowStorage {
+        type Temp<'a> = &'a Bytes;
+        type Value<'a> = Cow<'a, [u8]>;
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_> {
+            Cow::Borrowed(t.as_ref())
+        }
+    }
+}

--- a/packages/ic-response-verification-test-utils/Cargo.toml
+++ b/packages/ic-response-verification-test-utils/Cargo.toml
@@ -14,4 +14,4 @@ serde_cbor = "0.11"
 leb128 = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 flate2 = "1.0"
-ic-certification = { version = "0.26", default_features = false }
+ic-certification = { path = "../ic-certification", version = "1.1.0", default_features = false }

--- a/packages/ic-response-verification-wasm/Cargo.lock
+++ b/packages/ic-response-verification-wasm/Cargo.lock
@@ -852,9 +852,7 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d423020cc19ee52cb7fde4f64000d3dd6e8c5703947bf6d7911db5fb3428a8e"
+version = "1.1.0"
 dependencies = [
  "hex",
  "sha2 0.10.6",

--- a/packages/ic-response-verification/Cargo.toml
+++ b/packages/ic-response-verification/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 thiserror = "1.0"
 sha2 = "0.10"
 http = "0.2"
-ic-certification = { version = "0.26", default_features = false }
+ic-certification = { path = "../ic-certification", version = "1.1.0", default_features = false }
 ic-representation-independent-hash = { path = "../ic-representation-independent-hash", version = "1.1.0" }
 ic-cbor = { path = "../ic-cbor", version = "1.1.0" }
 ic-certificate-verification = { path = "../ic-certificate-verification", version = "1.1.0" }
@@ -42,7 +42,7 @@ urlencoding = "2.1.3"
 [dev-dependencies]
 serde_cbor = "0.11"
 wasm-bindgen-test = "0.3"
-ic-certification = "0.26.1"
+ic-certification = { path = "../ic-certification", version = "1.1.0" }
 candid = "0.9"
 serde = "1.0"
 ic-response-verification-test-utils = { path = "../ic-response-verification-test-utils" }

--- a/packages/ic-response-verification/src/error.rs
+++ b/packages/ic-response-verification/src/error.rs
@@ -230,7 +230,6 @@ mod tests {
     use crate::cel::CelParserError;
     use base64::{engine::general_purpose, Engine as _};
     use ic_response_verification_test_utils::hex_decode;
-    use std::array::TryFromSliceError;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
This moves the `ic-certification` library from https://github.com/dfinity/agent-rs.
I haven't made any code changes, although I made some slight alterations to the `Cargo.toml`. All changes outside of the `ic-certification` folder are the usual checklist items for adding new packages.