### PR TITLE
fix: missing certification object in CEL expressions

### DIFF
--- a/packages/ic-http-certification/src/cel/create_cel_expr.rs
+++ b/packages/ic-http-certification/src/cel/create_cel_expr.rs
@@ -18,8 +18,10 @@ fn create_default_cel_expr(certification: &Option<DefaultCertification>) -> Stri
     match certification {
         None => cel_expr.push_str("no_certification:Empty{}"),
         Some(certification) => {
+            cel_expr.push_str("certification:Certification{");
             create_request_cel_expr(&mut cel_expr, certification.request_certification.as_ref());
             create_response_cel_expr(&mut cel_expr, &certification.response_certification);
+            cel_expr.push_str("}");
         }
     }
 

--- a/packages/ic-http-certification/src/cel/fixtures.rs
+++ b/packages/ic-http-certification/src/cel/fixtures.rs
@@ -16,16 +16,18 @@ pub(super) fn no_request_response_inclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                no_request_certification: Empty {},
-                response_certification: ResponseCertification {
-                    certified_response_headers: ResponseHeaderList {
-                        headers: [
-                            "Cache-Control",
-                            "ETag",
-                            "Content-Length",
-                            "Content-Type",
-                            "Content-Encoding"
-                        ]
+                certification: Certification {
+                    no_request_certification: Empty {},
+                    response_certification: ResponseCertification {
+                        certified_response_headers: ResponseHeaderList {
+                            headers: [
+                                "Cache-Control",
+                                "ETag",
+                                "Content-Length",
+                                "Content-Type",
+                                "Content-Encoding"
+                            ]
+                        }
                     }
                 }
             }
@@ -38,14 +40,16 @@ pub(super) fn no_request_response_exclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                no_request_certification: Empty {},
-                response_certification: ResponseCertification {
-                    response_header_exclusions: ResponseHeaderList {
-                        headers: [
-                            "Date",
-                            "Cookie",
-                            "Set-Cookie"
-                        ]
+                certification: Certification {
+                    no_request_certification: Empty {},
+                    response_certification: ResponseCertification {
+                        response_header_exclusions: ResponseHeaderList {
+                            headers: [
+                                "Date",
+                                "Cookie",
+                                "Set-Cookie"
+                            ]
+                        }
                     }
                 }
             }
@@ -58,10 +62,12 @@ pub(super) fn no_request_empty_response_inclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                no_request_certification: Empty {},
-                response_certification: ResponseCertification {
-                    certified_response_headers: ResponseHeaderList {
-                        headers: []
+                certification: Certification {
+                    no_request_certification: Empty {},
+                    response_certification: ResponseCertification {
+                        certified_response_headers: ResponseHeaderList {
+                            headers: []
+                        }
                     }
                 }
             }
@@ -74,10 +80,12 @@ pub(super) fn no_request_empty_response_exclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                no_request_certification: Empty {},
-                response_certification: ResponseCertification {
-                    response_header_exclusions: ResponseHeaderList {
-                        headers: []
+                certification: Certification {
+                    no_request_certification: Empty {},
+                    response_certification: ResponseCertification {
+                        response_header_exclusions: ResponseHeaderList {
+                            headers: []
+                        }
                     }
                 }
             }
@@ -90,27 +98,29 @@ pub(super) fn include_request_response_header_inclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                request_certification: RequestCertification {
-                    certified_request_headers: [
-                        "Accept",
-                        "Accept-Encoding",
-                        "If-Match"
-                    ],
-                    certified_query_parameters: [
-                        "foo",
-                        "bar",
-                        "baz"
-                    ]
-                },
-                response_certification: ResponseCertification {
-                    certified_response_headers: ResponseHeaderList {
-                        headers: [
-                            "Cache-Control",
-                            "ETag",
-                            "Content-Length",
-                            "Content-Type",
-                            "Content-Encoding"
+                certification: Certification {
+                    request_certification: RequestCertification {
+                        certified_request_headers: [
+                            "Accept",
+                            "Accept-Encoding",
+                            "If-Match"
+                        ],
+                        certified_query_parameters: [
+                            "foo",
+                            "bar",
+                            "baz"
                         ]
+                    },
+                    response_certification: ResponseCertification {
+                        certified_response_headers: ResponseHeaderList {
+                            headers: [
+                                "Cache-Control",
+                                "ETag",
+                                "Content-Length",
+                                "Content-Type",
+                                "Content-Encoding"
+                            ]
+                        }
                     }
                 }
             }
@@ -123,25 +133,27 @@ pub(super) fn include_request_response_header_exclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                request_certification: RequestCertification {
-                    certified_request_headers: [
-                        "Accept",
-                        "Accept-Encoding",
-                        "If-Match"
-                    ],
-                    certified_query_parameters: [
-                        "foo",
-                        "bar",
-                        "baz"
-                    ]
-                },
-                response_certification: ResponseCertification {
-                    response_header_exclusions: ResponseHeaderList {
-                        headers: [
-                            "Date",
-                            "Cookie",
-                            "Set-Cookie"
+                certification: Certification {
+                    request_certification: RequestCertification {
+                        certified_request_headers: [
+                            "Accept",
+                            "Accept-Encoding",
+                            "If-Match"
+                        ],
+                        certified_query_parameters: [
+                            "foo",
+                            "bar",
+                            "baz"
                         ]
+                    },
+                    response_certification: ResponseCertification {
+                        response_header_exclusions: ResponseHeaderList {
+                            headers: [
+                                "Date",
+                                "Cookie",
+                                "Set-Cookie"
+                            ]
+                        }
                     }
                 }
             }
@@ -154,21 +166,23 @@ pub(super) fn include_request_empty_response_inclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                request_certification: RequestCertification {
-                    certified_request_headers: [
-                        "Accept",
-                        "Accept-Encoding",
-                        "If-Match"
-                    ],
-                    certified_query_parameters: [
-                        "foo",
-                        "bar",
-                        "baz"
-                    ]
-                },
-                response_certification: ResponseCertification {
-                    certified_response_headers: ResponseHeaderList {
-                        headers: []
+                certification: Certification {
+                    request_certification: RequestCertification {
+                        certified_request_headers: [
+                            "Accept",
+                            "Accept-Encoding",
+                            "If-Match"
+                        ],
+                        certified_query_parameters: [
+                            "foo",
+                            "bar",
+                            "baz"
+                        ]
+                    },
+                    response_certification: ResponseCertification {
+                        certified_response_headers: ResponseHeaderList {
+                            headers: []
+                        }
                     }
                 }
             }
@@ -181,21 +195,23 @@ pub(super) fn include_request_empty_response_exclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                request_certification: RequestCertification {
-                    certified_request_headers: [
-                        "Accept",
-                        "Accept-Encoding",
-                        "If-Match"
-                    ],
-                    certified_query_parameters: [
-                        "foo",
-                        "bar",
-                        "baz"
-                    ]
-                },
-                response_certification: ResponseCertification {
-                    response_header_exclusions: ResponseHeaderList {
-                        headers: []
+                certification: Certification {
+                    request_certification: RequestCertification {
+                        certified_request_headers: [
+                            "Accept",
+                            "Accept-Encoding",
+                            "If-Match"
+                        ],
+                        certified_query_parameters: [
+                            "foo",
+                            "bar",
+                            "baz"
+                        ]
+                    },
+                    response_certification: ResponseCertification {
+                        response_header_exclusions: ResponseHeaderList {
+                            headers: []
+                        }
                     }
                 }
             }
@@ -208,13 +224,15 @@ pub(super) fn empty_request_response_inclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                request_certification: RequestCertification {
-                    certified_request_headers: [],
-                    certified_query_parameters: []
-                },
-                response_certification: ResponseCertification {
-                    certified_response_headers: ResponseHeaderList {
-                        headers: []
+                certification: Certification {
+                    request_certification: RequestCertification {
+                        certified_request_headers: [],
+                        certified_query_parameters: []
+                    },
+                    response_certification: ResponseCertification {
+                        certified_response_headers: ResponseHeaderList {
+                            headers: []
+                        }
                     }
                 }
             }
@@ -227,13 +245,15 @@ pub(super) fn empty_request_response_exclusions_cel() -> String {
     remove_whitespace(
         r#"default_certification(
             ValidationArgs {
-                request_certification: RequestCertification {
-                    certified_request_headers: [],
-                    certified_query_parameters: []
-                },
-                response_certification: ResponseCertification {
-                    response_header_exclusions: ResponseHeaderList {
-                        headers: []
+                certification: Certification {
+                    request_certification: RequestCertification {
+                        certified_request_headers: [],
+                        certified_query_parameters: []
+                    },
+                    response_certification: ResponseCertification {
+                        response_header_exclusions: ResponseHeaderList {
+                            headers: []
+                        }
                     }
                 }
             }


### PR DESCRIPTION
After finishing the integration with the `ic-response-verification` the tests started failing because the CEL expressions were not valid 🙃