### PR TITLE
feat(ic-http-certification): add upgrade property to HttpResponse struct

### DIFF
--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
         status_code: 200,
         headers: http_response.headers,
         body: http_response.body,
+        upgrade: None,
     };
     println!("***Response***");
     println!("Body: {:?}", response.body);

--- a/packages/ic-cbor/src/cbor_parser.rs
+++ b/packages/ic-cbor/src/cbor_parser.rs
@@ -246,7 +246,7 @@ pub fn parse_cbor_string_array(i: &[u8]) -> CborResult<Vec<String>> {
         .map(|elem| {
             let CborValue::ByteString(elem) = elem else {
                 return Err(CborError::UnexpectedCborNodeType {
-                    expected_type: "Array".into(),
+                    expected_type: "ByteString".into(),
                     found_type: elem.to_string()
                 });
             };

--- a/packages/ic-http-certification/README.md
+++ b/packages/ic-http-certification/README.md
@@ -158,7 +158,7 @@ Typically these requests have been routed through `raw` Internet Computer URLs i
 
 ## Creating certifications
 
-Once a CEL expression has been defined, it can be used in conjunction with an `HttpRequest` and `HttpResponse` to create a [Certification]. The [Certification] enum has three variants, each with a corresponding associated function used to create that particular variant:
+Once a CEL expression has been defined, it can be used in conjunction with an `HttpRequest` and `HttpResponse` to create an instance of the `HttpCertification` enum. The `HttpCertification` enum has three variants, each with a corresponding associated function used to create that particular variant:
 
 - The `Full` variant is used to include both the `HttpRequest` and the corresponding `HttpResponse` in certification.
 - The `ResponseOnly` variant is used to include only the `HttpResponse` in certification and exclude the corresponding `HttpRequest` from certification.
@@ -169,7 +169,7 @@ Once a CEL expression has been defined, it can be used in conjunction with an `H
 To perform a full certification, a CEL expression created from `DefaultCelBuilder::full_certification` is required, along with an `HttpRequest` and `HttpResponse` and optionally, a pre-calculated response body hash. For example:
 
 ```rust
-use ic_http_certification::{Certification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
+use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
 
 let cel_expr = DefaultCelBuilder::full_certification()
     .with_request_headers(&["Accept", "Accept-Encoding", "If-None-Match"])
@@ -198,9 +198,10 @@ let response = HttpResponse {
         ("ETag".to_string(), "123456789".to_string()),
     ],
     body: vec![1, 2, 3, 4, 5, 6],
+    upgrade: None,
 };
 
-let certification = Certification::full(&cel_expr, &request, &response, None);
+let certification = HttpCertification::full(&cel_expr, &request, &response, None);
 ```
 
 ### Response-only certification
@@ -208,7 +209,7 @@ let certification = Certification::full(&cel_expr, &request, &response, None);
 To perform a response-only certification, a CEL expression created from `DefaultCelBuilder::response_only_certification` is required, along with an `HttpResponse` and optionally, a pre-calculated response body hash. For example:
 
 ```rust
-use ic_http_certification::{Certification, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
+use ic_http_certification::{HttpCertification, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
 
 let cel_expr = DefaultCelBuilder::response_only_certification()
     .with_response_certification(DefaultResponseCertification::certified_response_headers(&[
@@ -224,9 +225,10 @@ let response = HttpResponse {
         ("ETag".to_string(), "123456789".to_string()),
     ],
     body: vec![1, 2, 3, 4, 5, 6],
+    upgrade: None,
 };
 
-let certification = Certification::response_only(&cel_expr, &response, None);
+let certification = HttpCertification::response_only(&cel_expr, &response, None);
 ```
 
 ### Skipping certification
@@ -234,9 +236,9 @@ let certification = Certification::response_only(&cel_expr, &response, None);
 Skipping certification does not need an explicit CEL expression to be defined since it's always the same. For example:
 
 ```rust
-use ic_http_certification::Certification;
+use ic_http_certification::HttpCertification;
 
-let certification = Certification::skip();
+let certification = HttpCertification::skip();
 ```
 
 ## Directly creating a CEL expression

--- a/packages/ic-http-certification/src/hash/response_hash.rs
+++ b/packages/ic-http-certification/src/hash/response_hash.rs
@@ -231,6 +231,7 @@ mod tests {
                 ("Accept-Encoding".into(), "gzip".into()),
             ],
             body: HELLO_WORLD_BODY.into(),
+            upgrade: None,
         };
 
         let result = response_hash(&response, &response_certification, None);
@@ -276,6 +277,7 @@ mod tests {
                 ("Cache-Control".into(), "no-store".into()),
             ],
             body: HELLO_WORLD_BODY.into(),
+            upgrade: None,
         };
 
         let result = response_hash(&response, &response_certification, None);
@@ -321,6 +323,7 @@ mod tests {
                 ("Accept-Encoding".into(), "gzip".into()),
             ],
             body: HELLO_WORLD_BODY.into(),
+            upgrade: None,
         };
 
         let filtered_headers = filter_response_headers(&response, &response_certification);
@@ -370,6 +373,7 @@ mod tests {
                 ("Cache-Control".into(), "no-store".into()),
             ],
             body: HELLO_WORLD_BODY.into(),
+            upgrade: None,
         };
 
         let filtered_headers = filter_response_headers(&response, &response_certification);
@@ -424,6 +428,7 @@ mod tests {
                 ),
             ],
             body: HELLO_WORLD_BODY.into(),
+            upgrade: None,
         }
     }
 

--- a/packages/ic-http-certification/src/http/http_response.rs
+++ b/packages/ic-http-certification/src/http/http_response.rs
@@ -11,4 +11,6 @@ pub struct HttpResponse {
     pub headers: Vec<HeaderField>,
     /// Response body as an array of bytes.
     pub body: Vec<u8>,
+    /// Whether the request should be upgraded to an update call.
+    pub upgrade: Option<bool>,
 }

--- a/packages/ic-http-certification/src/lib.rs
+++ b/packages/ic-http-certification/src/lib.rs
@@ -161,18 +161,18 @@ Typically these requests have been routed through `raw` Internet Computer URLs i
 
 ## Creating certifications
 
-Once a CEL expression has been defined, it can be used in conjunction with an [HTTP request](HttpRequest) and [HTTP response](HttpResponse) to create a [Certification]. The [Certification] enum has three variants, each with a corresponding associated function used to create that particular variant:
+Once a CEL expression has been defined, it can be used in conjunction with an [HTTP request](HttpRequest) and [HTTP response](HttpResponse) to create an instance of the [HttpCertification] enum. The [HttpCertification] enum has three variants, each with a corresponding associated function used to create that particular variant:
 
-- The [Full](Certification::Full) variant is used to include both the [HTTP request](HttpRequest) and the corresponding [HTTP response](HttpResponse) in certification.
-- The [ResponseOnly](Certification::ResponseOnly) variant is used to include only the [HTTP response](HttpResponse) in certification and exclude the corresponding [HTTP request](HttpRequest) from certification.
-- The [Skip](Certification::Skip) variant is used to skip certification entirely.
+- The [Full](HttpCertification::Full) variant is used to include both the [HTTP request](HttpRequest) and the corresponding [HTTP response](HttpResponse) in certification.
+- The [ResponseOnly](HttpCertification::ResponseOnly) variant is used to include only the [HTTP response](HttpResponse) in certification and exclude the corresponding [HTTP request](HttpRequest) from certification.
+- The [Skip](HttpCertification::Skip) variant is used to skip certification entirely.
 
 ### Full certification
 
 To perform a full certification, a CEL expression created from [DefaultCelBuilder::full_certification] is required, along with an [HttpRequest] and [HttpResponse] and optionally, a pre-calculated response body hash. For example:
 
 ```rust
-use ic_http_certification::{Certification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
+use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
 
 let cel_expr = DefaultCelBuilder::full_certification()
     .with_request_headers(&["Accept", "Accept-Encoding", "If-None-Match"])
@@ -201,9 +201,10 @@ let response = HttpResponse {
         ("ETag".to_string(), "123456789".to_string()),
     ],
     body: vec![1, 2, 3, 4, 5, 6],
+    upgrade: None,
 };
 
-let certification = Certification::full(&cel_expr, &request, &response, None);
+let certification = HttpCertification::full(&cel_expr, &request, &response, None);
 ```
 
 ### Response-only certification
@@ -211,7 +212,7 @@ let certification = Certification::full(&cel_expr, &request, &response, None);
 To perform a response-only certification, a CEL expression created from [DefaultCelBuilder::response_only_certification] is required, along with an [HttpResponse] and optionally, a pre-calculated response body hash. For example:
 
 ```rust
-use ic_http_certification::{Certification, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
+use ic_http_certification::{HttpCertification, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
 
 let cel_expr = DefaultCelBuilder::response_only_certification()
     .with_response_certification(DefaultResponseCertification::certified_response_headers(&[
@@ -227,9 +228,10 @@ let response = HttpResponse {
         ("ETag".to_string(), "123456789".to_string()),
     ],
     body: vec![1, 2, 3, 4, 5, 6],
+    upgrade: None,
 };
 
-let certification = Certification::response_only(&cel_expr, &response, None);
+let certification = HttpCertification::response_only(&cel_expr, &response, None);
 ```
 
 ### Skipping certification
@@ -237,9 +239,9 @@ let certification = Certification::response_only(&cel_expr, &response, None);
 Skipping certification does not need an explicit CEL expression to be defined since it's always the same. For example:
 
 ```rust
-use ic_http_certification::Certification;
+use ic_http_certification::HttpCertification;
 
-let certification = Certification::skip();
+let certification = HttpCertification::skip();
 ```
 
 ## Directly creating a CEL expression

--- a/packages/ic-http-certification/src/tree/certification.rs
+++ b/packages/ic-http-certification/src/tree/certification.rs
@@ -9,24 +9,24 @@ use ic_representation_independent_hash::hash;
 ///
 /// It contains three variants:
 ///
-/// - The [Skip](Certification::Skip) variant excludes both an [HTTP request](crate::HttpRequest) and the
+/// - The [Skip](HttpCertification::Skip) variant excludes both an [HTTP request](crate::HttpRequest) and the
 /// corresponding [HTTP response](crate::HttpResponse) from certification. Create this variant using
-/// the associated [skip()](Certification::skip()) function.
+/// the associated [skip()](HttpCertification::skip()) function.
 ///
-/// - The [ResponseOnly](Certification::ResponseOnly) variant includes an
+/// - The [ResponseOnly](HttpCertification::ResponseOnly) variant includes an
 /// [HTTP response](crate::HttpResponse) but excludes the corresponding [HTTP request](crate::HttpRequest)
 /// from certification. Create this variant using the associated
-/// [response_only()](Certification::response_only()) function.
+/// [response_only()](HttpCertification::response_only()) function.
 ///
-/// - The [Full](Certification::Full) variant includes both an [HTTP response](crate::HttpResponse) and
+/// - The [Full](HttpCertification::Full) variant includes both an [HTTP response](crate::HttpResponse) and
 /// the corresponding [HTTP request](crate::HttpRequest) in certification. Create this variant using
-/// the [full()](Certification::full()) function.
-#[derive(Debug)]
-pub enum Certification {
+/// the [full()](HttpCertification::full()) function.
+#[derive(Debug, Clone)]
+pub enum HttpCertification {
     /// A certification that excludes both the [HTTP request](crate::HttpRequest) and
     /// the corresponding [HTTP response](crate::HttpResponse).
     ///
-    /// The [cel_expr_hash](Certification::Skip::cel_expr_hash) property is the hash
+    /// The [cel_expr_hash](HttpCertification::Skip::cel_expr_hash) property is the hash
     /// of a [CEL expression](crate::DefaultCelExpression::Skip) used to exclude both the
     /// [HTTP request](crate::HttpRequest) and the corresponding [HTTP response](crate::HttpResponse)
     /// from certification.
@@ -40,19 +40,19 @@ pub enum Certification {
     /// A certification that includes an [HTTP response](crate::HttpResponse), but excludes the
     /// corresponding [HTTP request](crate::HttpRequest).
     ///
-    /// The [cel_expr_hash](Certification::ResponseOnly::cel_expr_hash) property is the hash
+    /// The [cel_expr_hash](HttpCertification::ResponseOnly::cel_expr_hash) property is the hash
     /// of a [CEL expression](crate::DefaultCelExpression::ResponseOnly) used to include an
     /// [HTTP request](crate::HttpRequest) but exclude the corresponding
     /// [HTTP response](crate::HttpResponse) from certification.
     ///
-    /// The [response_hash](Certification::ResponseOnly::response_hash) property is the
+    /// The [response_hash](HttpCertification::ResponseOnly::response_hash) property is the
     /// hash of the [HTTP response](crate::HttpResponse) calculated according to a
     /// [CEL expression](crate::DefaultCelExpression::ResponseOnly).
     ///
     /// The [CEL expression](crate::DefaultCelExpression::ResponseOnly) used to produce
-    /// [response_hash](Certification::ResponseOnly::response_hash)
+    /// [response_hash](HttpCertification::ResponseOnly::response_hash)
     /// is also used to produce the
-    /// [cel_expr_hash](Certification::ResponseOnly::cel_expr_hash).
+    /// [cel_expr_hash](HttpCertification::ResponseOnly::cel_expr_hash).
     ResponseOnly {
         /// The hash of a [CEL expression](crate::DefaultCelExpression::ResponseOnly) used to include an
         /// [HTTP request](crate::HttpRequest) but exclude the corresponding
@@ -60,7 +60,7 @@ pub enum Certification {
         ///
         /// The [CEL expression](crate::DefaultCelExpression::ResponseOnly) that produces this hash
         /// is also used to produce the
-        /// [HTTP response hash](Certification::ResponseOnly::response_hash).
+        /// [HTTP response hash](HttpCertification::ResponseOnly::response_hash).
         cel_expr_hash: Hash,
 
         /// The
@@ -70,30 +70,30 @@ pub enum Certification {
         ///
         /// The [CEL expression](crate::DefaultCelExpression::ResponseOnly) used to calculate the hash of
         /// this [response](crate::HttpResponse), is also used to produce the
-        /// [cel_expr_hash](Certification::ResponseOnly::cel_expr_hash) property.
+        /// [cel_expr_hash](HttpCertification::ResponseOnly::cel_expr_hash) property.
         response_hash: Hash,
     },
 
     /// A certification that includes both an [HTTP response](crate::HttpResponse) and the corresponding
     /// [HTTP request](crate::HttpRequest).
     ///
-    /// The [cel_expr_hash](Certification::Full::cel_expr_hash) property is the hash
+    /// The [cel_expr_hash](HttpCertification::Full::cel_expr_hash) property is the hash
     /// of a [CEL expression](crate::DefaultCelExpression::Full) used to include both the
     /// [HTTP request](crate::HttpRequest) and the corresponding [HTTP response](crate::HttpResponse)
     /// in certification.
     ///
-    /// The [response_hash](Certification::Full::response_hash) property is the
+    /// The [response_hash](HttpCertification::Full::response_hash) property is the
     /// hash of the [HTTP response](crate::HttpResponse) calculated according to a
     /// [CEL expression](crate::DefaultCelExpression::Full).
     ///
-    /// The [request_hash](Certification::Full::request_hash) property is the hash of a
+    /// The [request_hash](HttpCertification::Full::request_hash) property is the hash of a
     /// [HTTP response](crate::HttpResponse) calculated according to a
     /// [CEL expression](crate::DefaultCelExpression::Full).
     ///
     /// The [CEL expression](crate::DefaultCelExpression::Full) used to produce both
-    /// [response_hash](Certification::Full::response_hash) and
-    /// [request_hash](Certification::Full::request_hash) is also used to produce the
-    /// [cel_expr_hash](Certification::Full::cel_expr_hash).
+    /// [response_hash](HttpCertification::Full::response_hash) and
+    /// [request_hash](HttpCertification::Full::request_hash) is also used to produce the
+    /// [cel_expr_hash](HttpCertification::Full::cel_expr_hash).
     Full {
         /// The hash of a [CEL expression](crate::DefaultCelExpression::Full) used to include an
         /// [HTTP request](crate::HttpRequest) but exclude the corresponding
@@ -101,8 +101,8 @@ pub enum Certification {
         ///
         /// The [CEL expression](crate::DefaultCelExpression::Full) that produces this hash
         /// is also used to produce the
-        /// [HTTP response hash](Certification::Full::response_hash) and the
-        /// [HTTP request hash](Certification::Full::request_hash).
+        /// [HTTP response hash](HttpCertification::Full::response_hash) and the
+        /// [HTTP request hash](HttpCertification::Full::request_hash).
         cel_expr_hash: Hash,
 
         /// The
@@ -112,7 +112,7 @@ pub enum Certification {
         ///
         /// The [CEL expression](crate::DefaultCelExpression::Full) used to calculate the hash of
         /// this [request](crate::HttpRequest), is also used to produce the
-        /// [cel_expr_hash](Certification::Full::cel_expr_hash) property.
+        /// [cel_expr_hash](HttpCertification::Full::cel_expr_hash) property.
         request_hash: Hash,
 
         /// The
@@ -122,40 +122,40 @@ pub enum Certification {
         ///
         /// The [CEL expression](crate::DefaultCelExpression::Full) used to calculate the hash of
         /// this [response](crate::HttpResponse), is also used to produce the
-        /// [cel_expr_hash](Certification::Full::cel_expr_hash) property.
+        /// [cel_expr_hash](HttpCertification::Full::cel_expr_hash) property.
         response_hash: Hash,
     },
 }
 
-impl Certification {
-    /// Creates the [Skip](Certification::Skip) variant of the [Certification] enum, excluding both an
+impl HttpCertification {
+    /// Creates the [Skip](HttpCertification::Skip) variant of the [HttpCertification] enum, excluding both an
     /// [HTTP request](crate::HttpRequest) and the corresponding [HTTP response](crate::HttpResponse)
     /// from certification.
-    pub fn skip() -> HttpCertificationResult<Certification> {
+    pub fn skip() -> HttpCertification {
         let cel_expr = DefaultCelBuilder::skip_certification().to_string();
         let cel_expr_hash = hash(&cel_expr.as_bytes());
 
-        Ok(Certification::Skip { cel_expr_hash })
+        HttpCertification::Skip { cel_expr_hash }
     }
 
-    /// Creates the [ResponseOnly](Certification::ResponseOnly) variant of the [Certification] enum,
+    /// Creates the [ResponseOnly](HttpCertification::ResponseOnly) variant of the [HttpCertification] enum,
     /// including an [HTTP response](crate::HttpResponse) but excluding the corresponding
     /// [HTTP request](crate::HttpRequest) from certification.
     pub fn response_only(
         cel_expr: &DefaultResponseOnlyCelExpression,
         response: &HttpResponse,
         response_body_hash: Option<Hash>,
-    ) -> HttpCertificationResult<Certification> {
+    ) -> HttpCertification {
         let cel_expr_hash = hash(cel_expr.to_string().as_bytes());
         let response_hash = response_hash(response, &cel_expr.response, response_body_hash);
 
-        Ok(Certification::ResponseOnly {
+        HttpCertification::ResponseOnly {
             cel_expr_hash,
             response_hash,
-        })
+        }
     }
 
-    /// Creates the [Full](Certification::Full) variant of the [Certification] enum, including both an
+    /// Creates the [Full](HttpCertification::Full) variant of the [HttpCertification] enum, including both an
     /// [HTTP request](crate::HttpRequest) and the corresponding [HTTP request](crate::HttpRequest)
     /// in certification.
     pub fn full(
@@ -163,12 +163,12 @@ impl Certification {
         request: &HttpRequest,
         response: &HttpResponse,
         response_body_hash: Option<Hash>,
-    ) -> HttpCertificationResult<Certification> {
+    ) -> HttpCertificationResult<HttpCertification> {
         let cel_expr_hash = hash(cel_expr.to_string().as_bytes());
         let request_hash = request_hash(request, &cel_expr.request)?;
         let response_hash = response_hash(response, &cel_expr.response, response_body_hash);
 
-        Ok(Certification::Full {
+        Ok(HttpCertification::Full {
             cel_expr_hash,
             request_hash,
             response_hash,
@@ -187,11 +187,11 @@ mod tests {
         let cel_expr = DefaultCelBuilder::skip_certification().to_string();
         let expected_cel_expr_hash = hash(cel_expr.as_bytes());
 
-        let result = Certification::skip().unwrap();
+        let result = HttpCertification::skip();
 
         assert!(matches!(
             result,
-            Certification::Skip { cel_expr_hash } if cel_expr_hash == expected_cel_expr_hash
+            HttpCertification::Skip { cel_expr_hash } if cel_expr_hash == expected_cel_expr_hash
         ));
     }
 
@@ -208,14 +208,15 @@ mod tests {
             status_code: 200,
             body: vec![],
             headers: vec![],
+            upgrade: None,
         };
         let expected_response_hash = response_hash(response, &cel_expr.response, None);
 
-        let result = Certification::response_only(&cel_expr, response, None).unwrap();
+        let result = HttpCertification::response_only(&cel_expr, response, None);
 
         assert!(matches!(
             result,
-            Certification::ResponseOnly {
+            HttpCertification::ResponseOnly {
                 cel_expr_hash,
                 response_hash
             } if cel_expr_hash == expected_cel_expr_hash &&
@@ -246,14 +247,15 @@ mod tests {
             status_code: 200,
             body: vec![],
             headers: vec![],
+            upgrade: None,
         };
         let expected_response_hash = response_hash(response, &cel_expr.response, None);
 
-        let result = Certification::full(&cel_expr, request, response, None).unwrap();
+        let result = HttpCertification::full(&cel_expr, request, response, None).unwrap();
 
         assert!(matches!(
             result,
-            Certification::Full {
+            HttpCertification::Full {
                 cel_expr_hash,
                 request_hash,
                 response_hash

--- a/packages/ic-http-certification/src/tree/mod.rs
+++ b/packages/ic-http-certification/src/tree/mod.rs
@@ -2,7 +2,7 @@
 //! [request](crate::HttpRequest) and [response](crate::HttpResponse) pairs in a
 //! purpose-build HTTP certification data structure.
 //!
-//! Certifications are prepared using the [Certification] enum.
+//! Certifications are prepared using the [HttpCertification] enum.
 
 mod certification;
 pub use certification::*;

--- a/packages/ic-response-verification-tests/src/main.rs
+++ b/packages/ic-response-verification-tests/src/main.rs
@@ -174,6 +174,7 @@ async fn perform_test(
             .collect(),
         body: response.body,
         status_code: response.status_code,
+        upgrade: None,
     };
     let current_time_ns = get_current_time();
     let max_cert_time_offset_ns = 300_000_000_000; // 5 mins

--- a/packages/ic-response-verification-wasm/src/response.rs
+++ b/packages/ic-response-verification-wasm/src/response.rs
@@ -51,6 +51,7 @@ pub fn response_from_js(resp: JsValue) -> HttpResponse {
         status_code,
         headers,
         body,
+        upgrade: None,
     }
 }
 
@@ -84,6 +85,7 @@ mod tests {
                     ("header1".into(), "header1val".into()),
                     ("header2".into(), "header2val".into()),
                 ],
+                upgrade: None,
             }
         );
     }

--- a/packages/ic-response-verification/tests/v1_response_verification.rs
+++ b/packages/ic-response-verification/tests/v1_response_verification.rs
@@ -51,6 +51,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
         let expected_response = VerifiedResponse {
             status_code: None,
@@ -114,6 +115,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
         let expected_response = VerifiedResponse {
             status_code: None,
@@ -176,6 +178,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
         let expected_response = VerifiedResponse {
             status_code: None,
@@ -238,6 +241,7 @@ mod tests {
             status_code: 200,
             body: b"Hello IC!".to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -292,6 +296,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -350,6 +355,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -410,6 +416,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -468,6 +475,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -523,6 +531,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -576,6 +585,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(
@@ -629,6 +639,7 @@ mod tests {
             status_code: 200,
             body: body.as_bytes().to_vec(),
             headers: vec![("IC-Certificate".into(), certificate_header)],
+            upgrade: None,
         };
 
         let result = verify_request_response_pair(

--- a/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_certification_scenarios.rs
@@ -325,6 +325,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "gzip".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -341,6 +342,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "gzip".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -357,6 +359,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "identity".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -372,6 +375,7 @@ mod fixtures {
                 ("Location".into(), "/new-path".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -387,6 +391,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "identity".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -402,6 +407,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "gzip".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -417,6 +423,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "deflate".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -449,6 +456,7 @@ mod fixtures {
                 ("Content-Encoding".into(), "deflate".into()),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 
@@ -483,6 +491,7 @@ mod fixtures {
                 ("ETag".into(), etag),
                 ("IC-CertificateExpression".into(), cel.to_string()),
             ],
+            upgrade: None,
         }
     }
 

--- a/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_happy_path.rs
@@ -34,6 +34,7 @@ mod tests {
                 ("IC-CertificateExpression".into(), cel_expr.to_string()),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         let V2Fixture {
@@ -93,6 +94,7 @@ mod tests {
                 ("IC-CertificateExpression".into(), cel_expr.clone()),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         let response_hash = response_hash(&response, &certification.response, None);
@@ -171,6 +173,7 @@ mod tests {
                 ("IC-CertificateExpression".into(), cel_expr.clone()),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         let request_hash = request_hash(&request, &certification.request).unwrap();
@@ -248,6 +251,7 @@ mod tests {
                 ("Content-Language".into(), "en-US".into()),
                 ("Server".into(), "Apache/2.4.1 (Unix)".into()),
             ],
+            upgrade: None,
         };
 
         let response_hash = response_hash(&response, &certification.response, None);

--- a/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-response-verification/tests/v2_response_verification_sad_path.rs
@@ -46,6 +46,7 @@ mod tests {
                 ("IC-CertificateExpression".into(), cel_expr.clone()),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         let request_hash =
@@ -111,6 +112,7 @@ mod tests {
                 ("IC-CertificateExpression".into(), cel_expr.clone()),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         let request_hash = request_hash(&request, &certification.request).unwrap();
@@ -180,6 +182,7 @@ mod tests {
                 ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         let request_hash = request_hash(&request, &certification.request).unwrap();
@@ -242,6 +245,7 @@ mod tests {
             status_code: 200,
             body: b"Hello World!".to_vec(),
             headers: vec![("IC-CertificateExpression".to_string(), cel_expr.clone())],
+            upgrade: None,
         };
 
         let cel_expr_hash = hash(&cel_expr);
@@ -346,6 +350,7 @@ mod tests {
                 ("IC-CertificateExpression".into(), cel_expr.clone()),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ],
+            upgrade: None,
         };
 
         response


### PR DESCRIPTION
Add the `upgrade` property on the `HttpResponse` object. Also rename `Certification` to `HttpCertification`.