### PR TITLE
feat: add support for hashing arrays of Value-objects

### DIFF
--- a/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
+++ b/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
@@ -49,7 +49,7 @@ fn hash_value(value: &Value) -> Sha256Digest {
 }
 
 // Arrays are hashed by hashing the concatenation of the hashes of the array elements.
-fn hash_array(elements: &Vec<Value>) -> Sha256Digest {
+fn hash_array(elements: &[Value]) -> Sha256Digest {
     let mut hasher = Sha256::new();
     elements
         .iter()

--- a/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
+++ b/packages/ic-representation-independent-hash/src/representation_independent_hash.rs
@@ -1,7 +1,7 @@
 use crate::{hash, Sha256Digest};
 use sha2::{Digest, Sha256};
 
-/// Represents a value to be hashed. Only UTF-8 strings, bytes and unsigned numbers are currently supported.
+/// Represents a value to be hashed. Only UTF-8 strings, bytes, unsigned numbers, and arrays are currently supported.
 #[derive(Debug, Clone)]
 pub enum Value {
     /// An UTF-8 string to be hashed.
@@ -10,6 +10,8 @@ pub enum Value {
     Number(u64),
     /// Bytes to be hashed.
     Bytes(Vec<u8>),
+    /// An array of values to be hashed.
+    Array(Vec<Value>),
 }
 
 /// A partial implementation of [`Representation Independent Hash`] that only supports
@@ -42,7 +44,18 @@ fn hash_value(value: &Value) -> Sha256Digest {
             leb128::write::unsigned(&mut hasher, value.to_owned()).unwrap();
             hasher.finalize().into()
         }
+        Value::Array(elements) => hash_array(elements),
     }
+}
+
+// Arrays are hashed by hashing the concatenation of the hashes of the array elements.
+fn hash_array(elements: &Vec<Value>) -> Sha256Digest {
+    let mut hasher = Sha256::new();
+    elements
+        .iter()
+        // Hash the encoding of all the array elements.
+        .for_each(|e| hasher.update(&hash_value(e)[..]));
+    hasher.finalize().into() // hash the concatenation of the hashes.
 }
 
 #[cfg(test)]
@@ -111,5 +124,78 @@ mod tests {
         let result = representation_independent_hash(&map);
 
         assert_eq!(result, expected_hash.as_slice());
+    }
+
+    fn from_hex(hex: &str) -> Vec<u8> {
+        hex::decode(hex).unwrap()
+    }
+
+    #[test]
+    fn hash_array_reference_1() {
+        let array = vec![Value::String("a".to_string())];
+        // hash(hash("a"))
+        let expected = from_hex("bf5d3affb73efd2ec6c36ad3112dd933efed63c4e1cbffcfa88e2759c144f2d8");
+        assert_eq!(hash_array(&array), expected.as_slice());
+        assert_eq!(hash_value(&Value::Array(array)), expected.as_slice());
+    }
+
+    #[test]
+    fn hash_array_reference_2() {
+        let array = vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ];
+        // hash(concat(hash("a"), hash("b"))
+        let expected = from_hex("e5a01fee14e0ed5c48714f22180f25ad8365b53f9779f79dc4a3d7e93963f94a");
+        assert_eq!(hash_array(&array), expected.as_slice());
+        assert_eq!(hash_value(&Value::Array(array)), expected.as_slice());
+    }
+
+    #[test]
+    fn hash_array_reference_3() {
+        let array = vec![
+            Value::Bytes(vec![97]), // "a" as a byte string.
+            Value::String("b".to_string()),
+        ];
+        // hash(concat(hash("a"), hash("b"))
+        let expected = from_hex("e5a01fee14e0ed5c48714f22180f25ad8365b53f9779f79dc4a3d7e93963f94a");
+        assert_eq!(hash_array(&array), expected.as_slice());
+        assert_eq!(hash_value(&Value::Array(array)), expected.as_slice());
+    }
+
+    #[test]
+    fn hash_array_reference_4() {
+        let array = vec![Value::Array(vec![Value::String("a".to_string())])];
+        // hash(hash(hash("a"))
+        let expected = from_hex("eb48bdfa15fc43dbea3aabb1ee847b6e69232c0f0d9705935e50d60cce77877f");
+        assert_eq!(hash_array(&array), expected.as_slice());
+        assert_eq!(hash_value(&Value::Array(array)), expected.as_slice());
+    }
+
+    #[test]
+    fn hash_array_reference_5() {
+        let array = vec![Value::Array(vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ])];
+        // hash(hash(concat(hash("a"), hash("b")))
+        let expected = from_hex("029fd80ca2dd66e7c527428fc148e812a9d99a5e41483f28892ef9013eee4a19");
+        assert_eq!(hash_array(&array), expected.as_slice());
+        assert_eq!(hash_value(&Value::Array(array)), expected.as_slice());
+    }
+
+    #[test]
+    fn hash_array_reference_6() {
+        let array = vec![
+            Value::Array(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+            Value::Bytes(vec![97]), // "a" in bytes
+        ];
+        // hash(concat(hash(concat(hash("a"), hash("b")), hash(100))
+        let expected = from_hex("aec3805593d9ec6df50da070597f73507050ce098b5518d0456876701ada7bb7");
+        assert_eq!(hash_array(&array), expected.as_slice());
+        assert_eq!(hash_value(&Value::Array(array)), expected.as_slice());
     }
 }


### PR DESCRIPTION
The current implementation is missing support for `Array`-values, this PR adds this support.