### PR TITLE
test(ic-http-certification): fix integration tests missing from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default-members = [
     "packages/ic-certificate-verification",
     "packages/ic-certification-testing",
     "packages/ic-http-certification",
+    "packages/ic-http-certification-tests",
     "packages/ic-representation-independent-hash",
     "packages/ic-response-verification",
     "packages/ic-response-verification-test-utils",

--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -328,7 +328,7 @@ fn certify_asset_glob(glob: &str, content_type: &str) {
 }
 ```
 
-Lastly, a function specifically to certify the `index.html` file. Since the frontend project is a single page application, any request that doesn't match an existing file should fallback to `index.html`, so certification is handled differently for this file, notably by using `HttpCertificationPath::Wildcard` instead of `HttpCertificationPath::Exact`.
+Lastly, a function specifically to certify the `index.html` file. Since the frontend project is a single page application, any request that doesn't match an existing file should fallback to `index.html`, so certification is handled differently for this file, notably by using `HttpCertificationPath::wildcard()` instead of `HttpCertificationPath::exact()`.
 
 This will allow the canister to return this file for any path that does not exactly match an existing path in the tree. If the canister tries to return this file instead of an exact match that exists, verification will fail.
 

--- a/packages/ic-http-certification-tests/tests/v2_response_verification_certification_scenarios.rs
+++ b/packages/ic-http-certification-tests/tests/v2_response_verification_certification_scenarios.rs
@@ -198,17 +198,17 @@ mod tests {
     #[case::etag_match(
         etag_caching_match_request(),
         etag_caching_match_response(),
-        etag_caching_match_certification(&HttpCertificationPath::Exact("/app"))
+        etag_caching_match_certification(HttpCertificationPath::exact("/app"))
     )]
     #[case::etag_match_mismatch_response(
         etag_caching_match_request(),
         etag_caching_mismatch_response(),
-        etag_caching_mismatch_certification(&HttpCertificationPath::Exact("/app"))
+        etag_caching_mismatch_certification(HttpCertificationPath::exact("/app"))
     )]
     #[case::etag_match_mismatch_response(
         etag_caching_mismatch_request(),
         etag_caching_mismatch_response(),
-        etag_caching_mismatch_certification(&HttpCertificationPath::Exact("/app"))
+        etag_caching_mismatch_certification(HttpCertificationPath::exact("/app"))
     )]
     fn etag_scenarios_pass_verification(
         #[from(etag_certificate_tree)] certification_tree: HttpCertificationTree,
@@ -274,7 +274,7 @@ mod tests {
     ) {
         let req_path = "/app";
         let http_certification_tree_entry =
-            etag_caching_match_certification(&HttpCertificationPath::Exact("/app"));
+            etag_caching_match_certification(HttpCertificationPath::exact("/app"));
         let current_time = get_current_timestamp();
 
         let V2CertificateFixture {
@@ -318,7 +318,6 @@ mod fixtures {
     };
     use ic_response_verification_test_utils::{deflate_encode, gzip_encode, hash};
     use rstest::*;
-    use std::borrow::Cow;
 
     pub const MAX_CERT_TIME_OFFSET_NS: u128 = 300_000_000_000;
     pub const MIN_REQUESTED_VERIFICATION_VERSION: u8 = 2;
@@ -346,14 +345,10 @@ mod fixtures {
 
     #[fixture]
     pub fn index_html_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Wildcard("")),
-            certification: Cow::Owned(HttpCertification::response_only(
-                &asset_cel(),
-                &index_html_response(),
-                None,
-            )),
-        }
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::wildcard(""),
+            HttpCertification::response_only(&asset_cel(), &index_html_response(), None),
+        )
     }
 
     #[fixture]
@@ -375,14 +370,10 @@ mod fixtures {
 
     #[fixture]
     pub fn index_js_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Exact("/js/index.js")),
-            certification: Cow::Owned(HttpCertification::response_only(
-                &asset_cel(),
-                &index_js_response(),
-                None,
-            )),
-        }
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::exact("/js/index.js"),
+            HttpCertification::response_only(&asset_cel(), &index_js_response(), None),
+        )
     }
 
     #[fixture]
@@ -404,14 +395,10 @@ mod fixtures {
 
     #[fixture]
     pub fn not_found_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Wildcard("/js")),
-            certification: Cow::Owned(HttpCertification::response_only(
-                &asset_cel(),
-                &not_found_response(),
-                None,
-            )),
-        }
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::wildcard("/js"),
+            HttpCertification::response_only(&asset_cel(), &not_found_response(), None),
+        )
     }
 
     #[fixture]
@@ -432,14 +419,10 @@ mod fixtures {
 
     #[fixture]
     pub fn redirect_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Exact("/old-path")),
-            certification: Cow::Owned(HttpCertification::response_only(
-                &redirect_cel(),
-                &redirect_response(),
-                None,
-            )),
-        }
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::exact("/old-path"),
+            HttpCertification::response_only(&redirect_cel(), &redirect_response(), None),
+        )
     }
 
     #[fixture]
@@ -460,14 +443,14 @@ mod fixtures {
 
     #[fixture]
     pub fn content_encoding_identity_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Exact("/multi-encoded-path")),
-            certification: Cow::Owned(HttpCertification::response_only(
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::exact("/multi-encoded-path"),
+            HttpCertification::response_only(
                 &asset_cel(),
                 &content_encoding_identity_response(),
                 None,
-            )),
-        }
+            ),
+        )
     }
 
     #[fixture]
@@ -488,14 +471,10 @@ mod fixtures {
 
     #[fixture]
     pub fn content_encoding_gzip_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Exact("/multi-encoded-path")),
-            certification: Cow::Owned(HttpCertification::response_only(
-                &asset_cel(),
-                &content_encoding_gzip_response(),
-                None,
-            )),
-        }
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::exact("/multi-encoded-path"),
+            HttpCertification::response_only(&asset_cel(), &content_encoding_gzip_response(), None),
+        )
     }
 
     #[fixture]
@@ -516,14 +495,14 @@ mod fixtures {
 
     #[fixture]
     pub fn content_encoding_deflate_certification() -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(&HttpCertificationPath::Exact("/multi-encoded-path")),
-            certification: Cow::Owned(HttpCertification::response_only(
+        HttpCertificationTreeEntry::new(
+            HttpCertificationPath::exact("/multi-encoded-path"),
+            HttpCertification::response_only(
                 &asset_cel(),
                 &content_encoding_deflate_response(),
                 None,
-            )),
-        }
+            ),
+        )
     }
 
     #[fixture]
@@ -561,20 +540,18 @@ mod fixtures {
 
     #[fixture]
     pub fn etag_caching_match_certification(
-        #[default(&HttpCertificationPath::Exact(""))] path: &'static HttpCertificationPath,
+        #[default(HttpCertificationPath::exact(""))] path: HttpCertificationPath<'static>,
     ) -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(path),
-            certification: Cow::Owned(
-                HttpCertification::full(
-                    &etag_caching_match_cel(),
-                    &etag_caching_match_request(),
-                    &etag_caching_match_response(),
-                    None,
-                )
-                .unwrap(),
-            ),
-        }
+        HttpCertificationTreeEntry::new(
+            path,
+            HttpCertification::full(
+                &etag_caching_match_cel(),
+                &etag_caching_match_request(),
+                &etag_caching_match_response(),
+                None,
+            )
+            .unwrap(),
+        )
     }
 
     #[fixture]
@@ -614,23 +591,23 @@ mod fixtures {
 
     #[fixture]
     pub fn etag_caching_mismatch_certification(
-        #[default(&HttpCertificationPath::Exact(""))] path: &'static HttpCertificationPath,
+        #[default(HttpCertificationPath::exact(""))] path: HttpCertificationPath<'static>,
     ) -> HttpCertificationTreeEntry<'static> {
-        HttpCertificationTreeEntry {
-            path: Cow::Borrowed(path),
-            certification: Cow::Owned(HttpCertification::response_only(
+        HttpCertificationTreeEntry::new(
+            path,
+            HttpCertification::response_only(
                 &etag_caching_mismatch_cel(),
                 &etag_caching_mismatch_response(),
                 None,
-            )),
-        }
+            ),
+        )
     }
 
     #[fixture]
     pub fn asset_cel() -> DefaultResponseOnlyCelExpression<'static> {
         DefaultCelBuilder::response_only_certification()
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Content-Type", "Content-Encoding"],
+                vec!["Content-Type", "Content-Encoding"],
             ))
             .build()
     }
@@ -639,7 +616,7 @@ mod fixtures {
     pub fn redirect_cel() -> DefaultResponseOnlyCelExpression<'static> {
         DefaultCelBuilder::response_only_certification()
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Location"],
+                vec!["Location"],
             ))
             .build()
     }
@@ -647,9 +624,9 @@ mod fixtures {
     #[fixture]
     pub fn etag_caching_match_cel() -> DefaultFullCelExpression<'static> {
         DefaultCelBuilder::full_certification()
-            .with_request_headers(&["If-None-Match"])
+            .with_request_headers(vec!["If-None-Match"])
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Content-Type", "Content-Encoding", "ETag"],
+                vec!["Content-Type", "Content-Encoding", "ETag"],
             ))
             .build()
     }
@@ -658,7 +635,7 @@ mod fixtures {
     pub fn etag_caching_mismatch_cel() -> DefaultResponseOnlyCelExpression<'static> {
         DefaultCelBuilder::response_only_certification()
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Content-Type", "Content-Encoding", "ETag"],
+                vec!["Content-Type", "Content-Encoding", "ETag"],
             ))
             .build()
     }
@@ -683,16 +660,16 @@ mod fixtures {
         let mut http_certification_tree = HttpCertificationTree::default();
 
         http_certification_tree.insert(&etag_caching_match_certification(
-            &HttpCertificationPath::Exact("/app"),
+            HttpCertificationPath::exact("/app"),
         ));
         http_certification_tree.insert(&etag_caching_match_certification(
-            &HttpCertificationPath::Exact("/app/"),
+            HttpCertificationPath::exact("/app/"),
         ));
         http_certification_tree.insert(&etag_caching_mismatch_certification(
-            &HttpCertificationPath::Exact("/app"),
+            HttpCertificationPath::exact("/app"),
         ));
         http_certification_tree.insert(&etag_caching_mismatch_certification(
-            &HttpCertificationPath::Exact("/app/"),
+            HttpCertificationPath::exact("/app/"),
         ));
 
         http_certification_tree

--- a/packages/ic-http-certification-tests/tests/v2_response_verification_happy_path.rs
+++ b/packages/ic-http-certification-tests/tests/v2_response_verification_happy_path.rs
@@ -19,7 +19,7 @@ mod tests {
         let req_path = "/";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
         let cel_expr = DefaultCelBuilder::skip_certification();
 
         let request = HttpRequest {
@@ -77,11 +77,11 @@ mod tests {
         let req_path = "/";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
 
         let cel_expr = DefaultCelBuilder::response_only_certification()
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Cache-Control"],
+                vec!["Cache-Control"],
             ))
             .build();
 
@@ -146,13 +146,13 @@ mod tests {
         let req_path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
 
         let cel_expr = DefaultCelBuilder::full_certification()
-            .with_request_headers(&["Cache-Control"])
-            .with_request_query_parameters(&["q"])
+            .with_request_headers(vec!["Cache-Control"])
+            .with_request_query_parameters(vec!["q"])
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Cache-Control"],
+                vec!["Cache-Control"],
             ))
             .build();
 
@@ -220,11 +220,11 @@ mod tests {
         let req_path = "/";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let expr_path = HttpCertificationPath::Exact("/");
+        let expr_path = HttpCertificationPath::exact("/");
 
         let cel_expr = DefaultCelBuilder::response_only_certification()
             .with_response_certification(DefaultResponseCertification::response_header_exclusions(
-                &["Content-Language", "Content-Encoding"],
+                vec!["Content-Language", "Content-Encoding"],
             ))
             .build();
 

--- a/packages/ic-http-certification-tests/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-http-certification-tests/tests/v2_response_verification_sad_path.rs
@@ -25,7 +25,7 @@ mod tests {
         let req_path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
 
         let request = HttpRequest {
             url: req_path.into(),
@@ -92,7 +92,7 @@ mod tests {
         let req_path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
 
         let request = HttpRequest {
             url: req_path.into(),
@@ -161,7 +161,7 @@ mod tests {
         let req_path = "/?q=greeting";
         let body = "Hello World!";
         let current_time = get_current_timestamp();
-        let certification_path = HttpCertificationPath::Exact("");
+        let certification_path = HttpCertificationPath::exact("");
 
         let request = HttpRequest {
             url: req_path.into(),
@@ -222,9 +222,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case::does_not_exist_in_tree(HttpCertificationPath::Wildcard("/assets/css"))]
-    #[case::more_specific_path_exists_in_tree(HttpCertificationPath::Wildcard("/assets"))]
-    #[case::does_not_match_request_url(HttpCertificationPath::Exact("/assets/js/dashboard.js"))]
+    #[case::does_not_exist_in_tree(HttpCertificationPath::wildcard("/assets/css"))]
+    #[case::more_specific_path_exists_in_tree(HttpCertificationPath::wildcard("/assets"))]
+    #[case::does_not_match_request_url(HttpCertificationPath::exact("/assets/js/dashboard.js"))]
     fn invalid_expr_path_fails_verification(
         #[from(skip_certification_cel)] cel_expr: CelExpression<'static>,
         #[case] certification_path: HttpCertificationPath,
@@ -248,15 +248,15 @@ mod tests {
         let certification = HttpCertification::skip();
         let mut certification_tree = HttpCertificationTree::default();
         certification_tree.insert(&HttpCertificationTreeEntry::new(
-            &HttpCertificationPath::Wildcard("/assets"),
+            &HttpCertificationPath::wildcard("/assets"),
             &certification,
         ));
         certification_tree.insert(&HttpCertificationTreeEntry::new(
-            &HttpCertificationPath::Wildcard("/assets/js"),
+            &HttpCertificationPath::wildcard("/assets/js"),
             &certification,
         ));
         certification_tree.insert(&HttpCertificationTreeEntry::new(
-            &HttpCertificationPath::Exact("/assets/js/dashboard.js"),
+            &HttpCertificationPath::exact("/assets/js/dashboard.js"),
             &certification,
         ));
 
@@ -392,10 +392,10 @@ mod fixtures {
     #[fixture]
     pub fn full_certification_cel() -> DefaultFullCelExpression<'static> {
         DefaultCelBuilder::full_certification()
-            .with_request_headers(&["Cache-Control"])
-            .with_request_query_parameters(&["q"])
+            .with_request_headers(vec!["Cache-Control"])
+            .with_request_query_parameters(vec!["q"])
             .with_response_certification(DefaultResponseCertification::certified_response_headers(
-                &["Cache-Control"],
+                vec!["Cache-Control"],
             ))
             .build()
     }
@@ -408,7 +408,7 @@ mod fixtures {
     pub fn invalid_root_key_certificate() -> (V2Fixture, u128, String) {
         let cel_expr = skip_certification_cel().to_string();
         let req_path = "/";
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
         let current_time = get_current_timestamp();
         let certification = HttpCertification::skip();
         let certification_tree_entry =
@@ -431,7 +431,7 @@ mod fixtures {
     pub fn expired_certificate() -> (V2Fixture, u128, String) {
         let cel_expr = skip_certification_cel().to_string();
         let req_path = "/";
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
         let current_time = get_current_timestamp();
         let certification = HttpCertification::skip();
         let certification_tree_entry =
@@ -451,7 +451,7 @@ mod fixtures {
     pub fn future_certificate() -> (V2Fixture, u128, String) {
         let cel_expr = skip_certification_cel().to_string();
         let req_path = "/";
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
         let current_time = get_current_timestamp();
         let certification = HttpCertification::skip();
         let certification_tree_entry =
@@ -471,7 +471,7 @@ mod fixtures {
     pub fn wrong_canister_certificate() -> (V2Fixture, u128, String) {
         let cel_expr = skip_certification_cel().to_string();
         let req_path = "/";
-        let certification_path = HttpCertificationPath::Exact("/");
+        let certification_path = HttpCertificationPath::exact("/");
         let other_canister_id = CanisterId::from_u64(15);
         let current_time = get_current_timestamp();
         let certification = HttpCertification::skip();

--- a/packages/ic-http-certification/README.md
+++ b/packages/ic-http-certification/README.md
@@ -269,9 +269,9 @@ let certification = HttpCertification::skip();
 
 ### Defining tree paths
 
-Paths for the tree can be defined using the `HttpCertificationPath` enum and come in two types: `Wildcard` and `Exact`. Both types of paths may end with or without a trailing slash, but note that a path ending in a trailing slash is a distinct path from one that does not end with a trailing slash, and they will be treated as such by the tree.
+Paths for the tree can be defined using the `HttpCertificationPath` struct and come in two types: `wildcard()` and `exact()`. Both types of paths may end with or without a trailing slash, but note that a path ending in a trailing slash is a distinct path from one that does not end with a trailing slash, and they will be treated as such by the tree.
 
-Wildcard paths can be used to match a sub-path of a request URL. This can be useful for 404 responses, fallbacks or rewrites. They are defined using the `Wildcard` variant.
+Wildcard paths can be used to match a sub-path of a request URL. This can be useful for 404 responses, fallbacks or rewrites. They are defined using the `wildcard()` associated function.
 
 In this example, the certification entered into the tree with this path will be valid for any request URL that begins with `/js`, unless there is a more specific path in the tree (ex. `/js/example.js`).
 

--- a/packages/ic-http-certification/src/lib.rs
+++ b/packages/ic-http-certification/src/lib.rs
@@ -270,9 +270,9 @@ let certification = HttpCertification::skip();
 
 ### Defining tree paths
 
-Paths for the tree can be defined using the [HttpCertificationPath] enum and come in two types - [Wildcard](HttpCertificationPath::Wildcard) and [Exact](HttpCertificationPath::Exact). Both types of paths may end with or without a trailing slash but note that a path ending in a trailing slash is a distinct path from one that does not end with a trailing slash and they will be treated as such by the tree.
+Paths for the tree can be defined using the [HttpCertificationPath] struct and come in two types - [Wildcard](HttpCertificationPath::wildcard()) and [Exact](HttpCertificationPath::exact()). Both types of paths may end with or without a trailing slash but note that a path ending in a trailing slash is a distinct path from one that does not end with a trailing slash and they will be treated as such by the tree.
 
-Wildcard paths can be used to match a sub-path of a request URL. This can be useful for 404 responses, fallbacks or rewrites. They are defined using the [Wildcard](HttpCertificationPath::Wildcard) variant.
+Wildcard paths can be used to match a sub-path of a request URL. This can be useful for 404 responses, fallbacks or rewrites. They are defined using the [Wildcard](HttpCertificationPath::wildcard()) associated function.
 
 In this example, the certification entered into the tree with this path will be valid for any request URL that begins with `/js`, unless there is a more specific path in the tree (ex. `/js/example.js` or `/js/example`).
 

--- a/packages/ic-http-certification/src/tree/certification_tree_path.rs
+++ b/packages/ic-http-certification/src/tree/certification_tree_path.rs
@@ -23,12 +23,12 @@ pub(super) enum HttpCertificationPathType<'a> {
 ///
 /// Two variants are supported:
 ///
-/// - The [Exact](HttpCertificationPath::Exact) variant is used for paths that match a full URL path.
-/// For example, `HttpCertificationPath::Exact('/foo')` will match the URL path `/foo` but not `/foo/bar`
+/// - The [Exact](HttpCertificationPath::exact()) variant is used for paths that match a full URL path.
+/// For example, `HttpCertificationPath::exact('/foo')` will match the URL path `/foo` but not `/foo/bar`
 /// or `/foo/baz`.
 ///
-/// - The [Wildcard](HttpCertificationPath::Wildcard) variant is used for paths that match a URL path prefix.
-/// For example, `HttpCertificationPath::Wildcard('/foo')` will match the URL paths `/foo/bar` and `/foo/baz`.
+/// - The [Wildcard](HttpCertificationPath::wildcard()) variant is used for paths that match a URL path prefix.
+/// For example, `HttpCertificationPath::wildcard('/foo')` will match the URL paths `/foo/bar` and `/foo/baz`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpCertificationPath<'a>(HttpCertificationPathType<'a>);
 


### PR DESCRIPTION
The `ic-http-certification-tests` crate was not part of the default members of the workspace, so the tests were not run with `cargo test`. Some changes were missed because of that, but thankfully nothing major.

I also found some parts of the docs that were missed for the same changes.