### PR TITLE
fix(ic-certificate-verification): redundant dependency

### DIFF
--- a/packages/ic-certificate-verification/Cargo.toml
+++ b/packages/ic-certificate-verification/Cargo.toml
@@ -33,10 +33,11 @@ parking_lot.workspace = true
 
 ic-certification = { workspace = true }
 ic-cbor.workspace = true
-ic-types.workspace = true
 
 [dev-dependencies]
 ic-response-verification-test-utils.workspace = true
 ic-certification-testing.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
+
+ic-types.workspace = true


### PR DESCRIPTION
This dependency caused the publish pipeline to fail because it's a git dependency: https://github.com/dfinity/response-verification/actions/runs/8357624688/job/22877166656.

Fortunately it's not actually used outside of tests, so the fix is simply moving to `dev-dependencies`.