### PR TITLE
feat(ic-asset-certification): add support for alt response encodings

### DIFF
--- a/packages/ic-asset-certification/src/asset.rs
+++ b/packages/ic-asset-certification/src/asset.rs
@@ -1,4 +1,7 @@
-use std::borrow::Cow;
+use std::{
+    borrow::Cow,
+    fmt::{Display, Formatter},
+};
 
 /// An asset to be certified and served by an [AssetRouter](crate::AssetRouter).
 ///
@@ -31,8 +34,9 @@ use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Asset<'content, 'path> {
     pub(crate) path: Cow<'path, str>,
-    pub(crate) url: String,
+    pub(crate) url: Cow<'path, str>,
     pub(crate) content: Cow<'content, [u8]>,
+    pub(crate) encoding: AssetEncoding,
 }
 
 impl<'content, 'path> Asset<'content, 'path> {
@@ -43,10 +47,60 @@ impl<'content, 'path> Asset<'content, 'path> {
         let path = path.into();
 
         Asset {
-            url: path_to_url(path.as_ref()),
+            url: Cow::Owned(path_to_url(path.as_ref())),
             path,
             content: content.into(),
+            encoding: AssetEncoding::Identity,
         }
+    }
+
+    /// Sets the encoding of the asset.
+    /// This method is chainable.
+    pub fn with_encoding(
+        path: impl Into<Cow<'path, str>>,
+        content: impl Into<Cow<'content, [u8]>>,
+        url: impl Into<Cow<'path, str>>,
+        encoding: AssetEncoding,
+    ) -> Self {
+        Asset {
+            url: url.into(),
+            path: path.into(),
+            content: content.into(),
+            encoding,
+        }
+    }
+}
+
+/// The encoding of an asset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AssetEncoding {
+    /// The asset is encoded with the Brotli algorithm.
+    Brotli,
+
+    /// The asset is encoded with the Zstd algorithm.
+    Zstd,
+
+    /// The asset is encoded with the Gzip algorithm.
+    Gzip,
+
+    /// The asset is encoded with the Deflate algorithm.
+    Deflate,
+
+    /// The asset is not encoded.
+    Identity,
+}
+
+impl Display for AssetEncoding {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            AssetEncoding::Brotli => "br".to_string(),
+            AssetEncoding::Zstd => "zstd".to_string(),
+            AssetEncoding::Gzip => "gzip".to_string(),
+            AssetEncoding::Deflate => "deflate".to_string(),
+            AssetEncoding::Identity => "identity".to_string(),
+        };
+
+        write!(f, "{}", str)
     }
 }
 
@@ -68,11 +122,12 @@ mod tests {
         let path = String::from("foo");
         let content = vec![1, 2, 3];
 
-        let asset = Asset::new(path, content);
+        let asset = Asset::new(path.clone(), content.clone());
 
-        assert_eq!(asset.path, "foo");
+        assert_eq!(asset.path, path);
         assert_eq!(asset.url, "/foo");
-        assert_eq!(asset.content, vec![1, 2, 3]);
+        assert_eq!(asset.content, content);
+        assert_eq!(asset.encoding, AssetEncoding::Identity);
     }
 
     #[rstest]
@@ -82,8 +137,33 @@ mod tests {
 
         let asset = Asset::new(path, content);
 
-        assert_eq!(asset.path, "foo");
+        assert_eq!(asset.path, path);
         assert_eq!(asset.url, "/foo");
-        assert_eq!(asset.content, vec![1, 2, 3]);
+        assert_eq!(asset.content, content);
+        assert_eq!(asset.encoding, AssetEncoding::Identity);
+    }
+
+    #[rstest]
+    fn asset_with_encoding() {
+        let path = "foo";
+        let content = [1, 2, 3].as_slice();
+        let url = "bar";
+        let encoding = AssetEncoding::Brotli;
+
+        let asset = Asset::with_encoding(path, content, url, encoding.clone());
+
+        assert_eq!(asset.path, path);
+        assert_eq!(asset.url, url);
+        assert_eq!(asset.content, content);
+        assert_eq!(asset.encoding, encoding);
+    }
+
+    #[rstest]
+    fn asset_encoding_to_string() {
+        assert_eq!(AssetEncoding::Brotli.to_string(), "br");
+        assert_eq!(AssetEncoding::Zstd.to_string(), "zstd");
+        assert_eq!(AssetEncoding::Gzip.to_string(), "gzip");
+        assert_eq!(AssetEncoding::Deflate.to_string(), "deflate");
+        assert_eq!(AssetEncoding::Identity.to_string(), "identity");
     }
 }


### PR DESCRIPTION
This is an initial PR for adding support for alternative response encodings, Gzip, brotli etc...
It works and is fully tested, but I'm not entirely happy with the interface. It currently requires adding additional configuration entries for the encoded versions, and I'd like to improve that but I still haven't fully decided how a better interface will look.
In the meantime it would be nice to merge it in it's current state and then re-iterate on the interface in a future PR.