### PR TITLE
chore: remove outdated crate categories

### DIFF
--- a/packages/ic-asset-certification/Cargo.toml
+++ b/packages/ic-asset-certification/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-asset-certification"
 description = "Certification for static assets served over HTTP on the Internet Computer"
 readme = "README.md"
 documentation = "https://docs.rs/ic-asset-certification"
-categories = ["api-bindings", "data-structures", "no-std"]
+categories = ["api-bindings", "data-structures", "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/packages/ic-cbor/Cargo.toml
+++ b/packages/ic-cbor/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-cbor"
 description = "CBOR decoding for Internet Computer clients"
 readme = "README.md"
 documentation = "https://docs.rs/ic-cbor"
-categories = ["api-bindings, "algorithms", "cryptography::cryptocurrencies"]
+categories = ["api-bindings", "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["internet-computer", "icp", "dfinity", "cbor"]
 include = ["src", "Cargo.toml", "README.md"]
 

--- a/packages/ic-cbor/Cargo.toml
+++ b/packages/ic-cbor/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-cbor"
 description = "CBOR decoding for Internet Computer clients"
 readme = "README.md"
 documentation = "https://docs.rs/ic-cbor"
-categories = ["api-bindings", "authentication", "cryptography"]
+categories = ["api-bindings, "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["internet-computer", "icp", "dfinity", "cbor"]
 include = ["src", "Cargo.toml", "README.md"]
 

--- a/packages/ic-certificate-verification/Cargo.toml
+++ b/packages/ic-certificate-verification/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-certificate-verification"
 description = "Certificate verification for the Internet Computer"
 readme = "README.md"
 documentation = "https://docs.rs/ic-certificate-verification"
-categories = ["api-bindings", "authentication", "cryptography"]
+categories = ["api-bindings", "algorithms", "cryptography::cryptocurrencies"]
 keywords = [
     "internet-computer",
     "icp",

--- a/packages/ic-certification-testing/Cargo.toml
+++ b/packages/ic-certification-testing/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-certification-testing"
 description = "Utilities for testing applications that work with Internet Computer certification"
 readme = "README.md"
 documentation = "https://docs.rs/ic-certification-testing"
-categories = ["api-bindings", "authentication", "cryptography"]
+categories = ["api-bindings", "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["internet-computer", "icp", "dfinity", "certification", "testing"]
 include = ["src", "Cargo.toml", "README.md"]
 

--- a/packages/ic-certification/Cargo.toml
+++ b/packages/ic-certification/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-certification"
 description = "Types related to the Internet Computer Public Specification."
 readme = "README.md"
 documentation = "https://docs.rs/ic-certification"
-categories = ["api-bindings", "data-structures", "no-std"]
+categories = ["api-bindings", "data-structures", "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/packages/ic-http-certification/Cargo.toml
+++ b/packages/ic-http-certification/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-http-certification"
 description = "Certification for HTTP responses for the Internet Computer"
 readme = "README.md"
 documentation = "https://docs.rs/ic-http-certification"
-categories = ["api-bindings", "data-structures", "no-std"]
+categories = ["api-bindings", "data-structures", "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 

--- a/packages/ic-representation-independent-hash/Cargo.toml
+++ b/packages/ic-representation-independent-hash/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-representation-independent-hash"
 description = "A library for computing representation-independent hashes as described in the Internet Computer interface specification."
 readme = "README.md"
 documentation = "https://docs.rs/ic-representation-independent-hash"
-categories = ["cryptography", "hash"]
+categories = ["api-bindings", "algorithms", "cryptography::cryptocurrencies"]
 keywords = ["icp", "dfinity", "representation", "independent", "hash"]
 include = ["src", "Cargo.toml", "README.md"]
 

--- a/packages/ic-response-verification/Cargo.toml
+++ b/packages/ic-response-verification/Cargo.toml
@@ -3,7 +3,7 @@ name = "ic-response-verification"
 description = "Client side response verification for the Internet Computer"
 readme = "README.md"
 documentation = "https://docs.rs/ic-response-verification"
-categories = ["api-bindings", "authentication", "cryptography", "wasm"]
+categories = ["api-bindings", "algorithms", "cryptography::cryptocurrencies", "wasm"]
 keywords = ["internet-computer", "icp", "dfinity", "response", "verification"]
 include = ["src", "Cargo.toml", "README.md"]
 


### PR DESCRIPTION
The release pipeline has [failed](https://github.com/dfinity/response-verification/actions/runs/10078240807/job/27862694811) because the `hash` category seems to have been removed from crates.io, although I can't find any explanation as to when or why that happened.

I took the time to review the categories of all crates just in case there's other examples, but there wasn't. So not all changes are necessary but I think the categories make more sense now.