### PR TITLE
feat(ic-http-certification): add add_certificate_header util function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -67,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
 
 [[package]]
 name = "arrayvec"
@@ -119,17 +113,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -371,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "shlex",
 ]
@@ -496,9 +490,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -795,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -934,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -946,9 +940,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1073,54 +1067,35 @@ dependencies = [
 name = "http_certification_assets_backend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "base64 0.21.7",
+ "candid",
+ "ic-asset-certification",
+ "ic-cdk",
+ "ic-http-certification",
+ "include_dir",
+]
+
+[[package]]
+name = "http_certification_custom_assets_backend"
+version = "0.1.0"
+dependencies = [
  "candid",
  "ic-cdk",
- "ic-cdk-macros",
  "ic-http-certification",
  "include_dir",
  "lazy_static",
- "serde",
- "serde_cbor",
- "sha2 0.10.8",
 ]
 
 [[package]]
 name = "http_certification_json_api_backend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "base64 0.21.7",
  "candid",
  "ic-cdk",
- "ic-cdk-macros",
  "ic-http-certification",
  "lazy_static",
  "matchit",
  "serde",
- "serde_cbor",
  "serde_json",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "http_certification_new_assets_backend"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64 0.21.7",
- "candid",
- "ic-asset-certification",
- "ic-cdk",
- "ic-cdk-macros",
- "ic-certification 2.6.0",
- "ic-http-certification",
- "include_dir",
- "lazy_static",
- "serde",
- "serde_cbor",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1563,6 +1538,7 @@ dependencies = [
 name = "ic-http-certification"
 version = "2.6.0"
 dependencies = [
+ "base64 0.21.7",
  "candid",
  "hex",
  "http",
@@ -1571,6 +1547,7 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "serde",
+ "serde_cbor",
  "thiserror",
  "urlencoding",
 ]
@@ -1925,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "itertools"
@@ -2049,15 +2026,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2383,9 +2351,9 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2677,9 +2645,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -2716,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3206,9 +3174,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"

--- a/examples/http-certification/assets/README.md
+++ b/examples/http-certification/assets/README.md
@@ -245,13 +245,13 @@ fn certify_all_assets() {
 
 ## Serving assets
 
-The `serve_asset` function is responsible for serving assets. It uses the `serve_asset` function from the `AssetRouter` to serve the assets. This function returns the `HttpResponse`, a witness (`HashTree`), and an expression path. The witness and expression path is used to generate the `IC-Certificate` header, which is added to the response before returning it. To add the `IC-Certificate` header to the response, the `add_certificate_header` function from the `ic-http-certification` crate is used. This function takes the data certificate, response, witness, and expression path as arguments. The witness, expression path, and the canister's certified data are encoded using CBOR and then added to the response headers.
+The `serve_asset` function is responsible for serving assets. It uses the `serve_asset` function from the `AssetRouter` to serve the assets. This function returns the `HttpResponse`, a witness (`HashTree`), and an expression path. The witness and expression path is used to generate the `IC-Certificate` header, which is added to the response before returning it. To add the `IC-Certificate` header to the response, the `add_v2_certificate_header` function from the `ic-http-certification` crate is used. This function takes the data certificate, response, witness, and expression path as arguments. The witness, expression path, and the canister's certified data are encoded using CBOR and then added to the response headers.
 
 ```rust
 fn serve_asset(req: &HttpRequest) -> HttpResponse<'static> {
     ASSET_ROUTER.with_borrow(|asset_router| {
         if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
-            add_certificate_header(
+            add_v2_certificate_header(
                 data_certificate().expect("No data certificate available"),
                 &mut response,
                 &witness,

--- a/examples/http-certification/assets/README.md
+++ b/examples/http-certification/assets/README.md
@@ -245,50 +245,23 @@ fn certify_all_assets() {
 
 ## Serving assets
 
-The `serve_asset` function is responsible for serving assets. It uses the `serve_asset` function from the `AssetRouter` to serve the assets. This function returns the `HttpResponse`, a witness (`HashTree`), and an expression path. The witness and expression path is used to generate the `IC-Certificate` header, which is added to the response before returning it.
+The `serve_asset` function is responsible for serving assets. It uses the `serve_asset` function from the `AssetRouter` to serve the assets. This function returns the `HttpResponse`, a witness (`HashTree`), and an expression path. The witness and expression path is used to generate the `IC-Certificate` header, which is added to the response before returning it. To add the `IC-Certificate` header to the response, the `add_certificate_header` function from the `ic-http-certification` crate is used. This function takes the data certificate, response, witness, and expression path as arguments. The witness, expression path, and the canister's certified data are encoded using CBOR and then added to the response headers.
 
 ```rust
 fn serve_asset(req: &HttpRequest) -> HttpResponse<'static> {
     ASSET_ROUTER.with_borrow(|asset_router| {
         if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
-            add_certificate_header(&mut response, &witness, &expr_path);
+            add_certificate_header(
+                data_certificate().expect("No data certificate available"),
+                &mut response,
+                &witness,
+                &expr_path,
+            );
 
             response
         } else {
             ic_cdk::trap("Failed to serve asset");
         }
     })
-}
-```
-
-To add the `IC-Certificate` header to the response, the `add_certificate_header` function is used. This function takes the response, witness, and expression path as arguments. The witness, expression path, and the canister's certified data are encoded using CBOR and then added to the response headers.
-
-```rust
-const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
-fn add_certificate_header(response: &mut HttpResponse, witness: &HashTree, expr_path: &[String]) {
-    let certified_data = data_certificate().expect("No data certificate available");
-    let witness = cbor_encode(witness);
-    let expr_path = cbor_encode(&expr_path);
-
-    response.add_header((
-        IC_CERTIFICATE_HEADER.to_string(),
-        format!(
-            "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
-            BASE64.encode(certified_data),
-            BASE64.encode(witness),
-            BASE64.encode(expr_path)
-        ),
-    ));
-}
-
-fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
-    let mut serializer = serde_cbor::Serializer::new(Vec::new());
-    serializer
-        .self_describe()
-        .expect("Failed to self describe CBOR");
-    value
-        .serialize(&mut serializer)
-        .expect("Failed to serialize value");
-    serializer.into_inner()
 }
 ```

--- a/examples/http-certification/assets/dfx.json
+++ b/examples/http-certification/assets/dfx.json
@@ -6,12 +6,12 @@
     "backend": {
       "type": "custom",
       "candid": "src/backend/backend.did",
-      "wasm": "../../../target/wasm32-unknown-unknown/release/http_certification_new_assets_backend.wasm",
+      "wasm": "../../../target/wasm32-unknown-unknown/release/http_certification_assets_backend.wasm",
       "gzip": true,
       "optimize": "cycles",
       "build": [
         "pnpm -F http-certification-assets-frontend build",
-        "cargo build --target wasm32-unknown-unknown --release -p http_certification_new_assets_backend --locked"
+        "cargo build --target wasm32-unknown-unknown --release -p http_certification_assets_backend --locked"
       ]
     }
   }

--- a/examples/http-certification/assets/src/backend/Cargo.toml
+++ b/examples/http-certification/assets/src/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http_certification_new_assets_backend"
+name = "http_certification_assets_backend"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,16 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow.workspace = true
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
-serde.workspace = true
-serde_cbor.workspace = true
-sha2.workspace = true
-ic-certification.workspace = true
-ic-http-certification = { workspace = true, features = ["serde"] }
+ic-http-certification.workspace = true
 ic-asset-certification.workspace = true
-lazy_static.workspace = true
-base64.workspace = true
 include_dir = { version = "0.7", features = ["glob"] }

--- a/examples/http-certification/assets/src/backend/src/lib.rs
+++ b/examples/http-certification/assets/src/backend/src/lib.rs
@@ -6,7 +6,7 @@ use ic_cdk::{
     *,
 };
 use ic_http_certification::{
-    utils::add_certificate_header, HeaderField, HttpCertificationTree, HttpRequest, HttpResponse,
+    utils::add_v2_certificate_header, HeaderField, HttpCertificationTree, HttpRequest, HttpResponse,
 };
 use include_dir::{include_dir, Dir};
 use std::{cell::RefCell, rc::Rc};
@@ -137,7 +137,7 @@ fn certify_all_assets() {
 fn serve_asset(req: &HttpRequest) -> HttpResponse<'static> {
     ASSET_ROUTER.with_borrow(|asset_router| {
         if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
-            add_certificate_header(
+            add_v2_certificate_header(
                 data_certificate().expect("No data certificate available"),
                 &mut response,
                 &witness,

--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -469,7 +469,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
             let mut response = response.clone();
 
             HTTP_TREE.with_borrow(|http_tree| {
-                add_certificate_header(
+                add_v2_certificate_header(
                     data_certificate().expect("No data certificate available"),
                     &mut response,
                     &http_tree

--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -157,7 +157,7 @@ fn create_asset_response(
         ("cross-origin-embedder-policy".to_string(), "require-corp".to_string()),
         ("cross-origin-opener-policy".to_string(), "same-origin".to_string()),
         ("content-length".to_string(), body.len().to_string()),
-        (IC_CERTIFICATE_EXPRESSION_HEADER.to_string(), cel_expr),
+        (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
     ];
     headers.extend(additional_headers);
 
@@ -172,7 +172,6 @@ fn create_asset_response(
 The next function to look at is a reusable function that can certify any asset.
 
 ```rust
-const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
 fn certify_asset_response(
     body: &'static [u8],
     additional_headers: Vec<HeaderField>,
@@ -469,12 +468,19 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
             let mut response = response.clone();
 
-            add_certificate_header(
-                &mut response,
-                &HttpCertificationTreeEntry::new(&asset_tree_path, certification),
-                &req_path,
-                &asset_tree_path.to_expr_path(),
-            );
+            HTTP_TREE.with_borrow(|http_tree| {
+                add_certificate_header(
+                    data_certificate().expect("No data certificate available"),
+                    &mut response,
+                    &http_tree
+                        .witness(
+                            &HttpCertificationTreeEntry::new(&asset_tree_path, certification),
+                            &req_path,
+                        )
+                        .unwrap(),
+                    &asset_tree_path.to_expr_path(),
+                );
+            });
 
             response
         })
@@ -496,4 +502,4 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 - [Example source code](https://github.com/dfinity/response-verification/tree/main/examples/http-certification/custom-assets).
 - [`ic-http-certification` crate](https://crates.io/crates/ic-http-certification).
 - [`ic-http-certification` docs](https://docs.rs/ic-http-certification/latest/ic_http_certification).
-- [`ic-http-certification` source code](https://github.com/dfinity/response-verification/tree/main/packages/ic-http-certification)
+- [`ic-http-certification` source code](https://github.com/dfinity/response-verification/tree/main/packages/ic-http-certification).

--- a/examples/http-certification/custom-assets/dfx.json
+++ b/examples/http-certification/custom-assets/dfx.json
@@ -6,12 +6,12 @@
     "backend": {
       "type": "custom",
       "candid": "src/backend/backend.did",
-      "wasm": "../../../target/wasm32-unknown-unknown/release/http_certification_assets_backend.wasm",
+      "wasm": "../../../target/wasm32-unknown-unknown/release/http_certification_custom_assets_backend.wasm",
       "gzip": true,
       "optimize": "cycles",
       "build": [
         "pnpm -F http-certification-custom-assets-frontend build",
-        "cargo build --target wasm32-unknown-unknown --release -p http_certification_assets_backend --locked"
+        "cargo build --target wasm32-unknown-unknown --release -p http_certification_custom_assets_backend --locked"
       ]
     }
   }

--- a/examples/http-certification/custom-assets/src/backend/Cargo.toml
+++ b/examples/http-certification/custom-assets/src/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "http_certification_assets_backend"
+name = "http_certification_custom_assets_backend"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,14 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow.workspace = true
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
-serde.workspace = true
-serde_cbor.workspace = true
-sha2.workspace = true
-ic-http-certification = { workspace = true, features = ["serde"] }
-base64.workspace = true
+ic-http-certification.workspace = true
 lazy_static.workspace = true
 include_dir = { version = "0.7", features = ["glob"] }

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -1,17 +1,15 @@
-use base64::engine::general_purpose::STANDARD as BASE64;
-use base64::Engine;
 use ic_cdk::{
     api::{data_certificate, set_certified_data},
     *,
 };
 use ic_http_certification::{
-    DefaultCelBuilder, DefaultResponseCertification, DefaultResponseOnlyCelExpression, HeaderField,
-    HttpCertification, HttpCertificationPath, HttpCertificationTree, HttpCertificationTreeEntry,
-    HttpRequest, HttpResponse,
+    utils::add_certificate_header, DefaultCelBuilder, DefaultResponseCertification,
+    DefaultResponseOnlyCelExpression, HeaderField, HttpCertification, HttpCertificationPath,
+    HttpCertificationTree, HttpCertificationTreeEntry, HttpRequest, HttpResponse,
+    CERTIFICATE_EXPRESSION_HEADER_NAME,
 };
 use include_dir::{include_dir, Dir};
 use lazy_static::lazy_static;
-use serde::Serialize;
 use std::{cell::RefCell, collections::HashMap};
 
 // Public methods
@@ -221,7 +219,6 @@ fn certify_asset_with_encoding(
     };
 }
 
-const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
 fn certify_asset_response(
     body: &'static [u8],
     additional_headers: Vec<HeaderField>,
@@ -325,42 +322,23 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
             let mut response = response.clone();
 
-            add_certificate_header(
-                &mut response,
-                &HttpCertificationTreeEntry::new(&asset_tree_path, certification),
-                &req_path,
-                &asset_tree_path.to_expr_path(),
-            );
+            HTTP_TREE.with_borrow(|http_tree| {
+                add_certificate_header(
+                    data_certificate().expect("No data certificate available"),
+                    &mut response,
+                    &http_tree
+                        .witness(
+                            &HttpCertificationTreeEntry::new(&asset_tree_path, certification),
+                            &req_path,
+                        )
+                        .unwrap(),
+                    &asset_tree_path.to_expr_path(),
+                );
+            });
 
             response
         })
     })
-}
-
-const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
-fn add_certificate_header(
-    response: &mut HttpResponse,
-    entry: &HttpCertificationTreeEntry,
-    request_url: &str,
-    expr_path: &[String],
-) {
-    let certified_data = data_certificate().expect("No data certificate available");
-    let witness = HTTP_TREE.with_borrow(|http_tree| {
-        let witness = http_tree.witness(entry, request_url).unwrap();
-
-        cbor_encode(&witness)
-    });
-    let expr_path = cbor_encode(&expr_path);
-
-    response.add_header((
-        IC_CERTIFICATE_HEADER.to_string(),
-        format!(
-            "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
-            BASE64.encode(certified_data),
-            BASE64.encode(witness),
-            BASE64.encode(expr_path)
-        ),
-    ));
 }
 
 fn create_asset_response(
@@ -379,7 +357,7 @@ fn create_asset_response(
         ("cross-origin-embedder-policy".to_string(), "require-corp".to_string()),
         ("cross-origin-opener-policy".to_string(), "same-origin".to_string()),
         ("content-length".to_string(), body.len().to_string()),
-        (IC_CERTIFICATE_EXPRESSION_HEADER.to_string(), cel_expr),
+        (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
     ];
     headers.extend(additional_headers);
 
@@ -388,16 +366,4 @@ fn create_asset_response(
         .with_headers(headers)
         .with_body(body)
         .build()
-}
-
-// Encoding
-fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
-    let mut serializer = serde_cbor::Serializer::new(Vec::new());
-    serializer
-        .self_describe()
-        .expect("Failed to self describe CBOR");
-    value
-        .serialize(&mut serializer)
-        .expect("Failed to serialize value");
-    serializer.into_inner()
 }

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -3,7 +3,7 @@ use ic_cdk::{
     *,
 };
 use ic_http_certification::{
-    utils::add_certificate_header, DefaultCelBuilder, DefaultResponseCertification,
+    utils::add_v2_certificate_header, DefaultCelBuilder, DefaultResponseCertification,
     DefaultResponseOnlyCelExpression, HeaderField, HttpCertification, HttpCertificationPath,
     HttpCertificationTree, HttpCertificationTreeEntry, HttpRequest, HttpResponse,
     CERTIFICATE_EXPRESSION_HEADER_NAME,
@@ -323,7 +323,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
             let mut response = response.clone();
 
             HTTP_TREE.with_borrow(|http_tree| {
-                add_certificate_header(
+                add_v2_certificate_header(
                     data_certificate().expect("No data certificate available"),
                     &mut response,
                     &http_tree

--- a/examples/http-certification/json-api/README.md
+++ b/examples/http-certification/json-api/README.md
@@ -380,7 +380,7 @@ fn query_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'stati
     let mut response = certified_response.response;
 
     HTTP_TREE.with_borrow(|http_tree| {
-        add_certificate_header(
+        add_v2_certificate_header(
             data_certificate().expect("No data certificate available"),
             &mut response,
             &http_tree

--- a/examples/http-certification/json-api/src/backend/Cargo.toml
+++ b/examples/http-certification/json-api/src/backend/Cargo.toml
@@ -7,15 +7,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow.workspace = true
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
 serde.workspace = true
-serde_cbor.workspace = true
-sha2.workspace = true
-ic-http-certification = { workspace = true, features = ["serde"] }
-base64.workspace = true
+ic-http-certification.workspace = true
 lazy_static.workspace = true
 serde_json = "1.0"
 matchit = "0.8"

--- a/examples/http-certification/json-api/src/backend/src/lib.rs
+++ b/examples/http-certification/json-api/src/backend/src/lib.rs
@@ -3,7 +3,7 @@ use ic_cdk::{
     *,
 };
 use ic_http_certification::{
-    utils::add_certificate_header, DefaultCelBuilder, DefaultFullCelExpression,
+    utils::add_v2_certificate_header, DefaultCelBuilder, DefaultFullCelExpression,
     DefaultResponseCertification, DefaultResponseOnlyCelExpression, HttpCertification,
     HttpCertificationPath, HttpCertificationTree, HttpCertificationTreeEntry, HttpRequest,
     HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
@@ -365,7 +365,7 @@ fn query_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'stati
     let mut response = certified_response.response;
 
     HTTP_TREE.with_borrow(|http_tree| {
-        add_certificate_header(
+        add_v2_certificate_header(
             data_certificate().expect("No data certificate available"),
             &mut response,
             &http_tree

--- a/packages/ic-asset-certification/README.md
+++ b/packages/ic-asset-certification/README.md
@@ -455,10 +455,12 @@ asset_router.init_with_tree(http_certification_tree.clone());
 
 ## Serving assets
 
-Assets can be served by calling the `serve_asset` method on the `AssetRouter`:
+Assets can be served by calling the `serve_asset` method on the `AssetRouter`.
+This method will return a response, a witness and an expression path, which can be used
+alongside the canister's data certificate to add the required certificate header to the response.
 
 ```rust
-use ic_http_certification::HttpRequest;
+use ic_http_certification::{HttpRequest, utils::add_certificate_header};
 use ic_asset_certification::{Asset, AssetConfig, AssetFallbackConfig, AssetRouter};
 
 let mut asset_router = AssetRouter::default();
@@ -485,47 +487,17 @@ let http_request = HttpRequest::get("/").build();
 
 asset_router.certify_assets(vec![asset], vec![asset_config]).unwrap();
 
-let (response, witness, expr_path) = asset_router.serve_asset(&http_request).unwrap();
-```
+let (mut response, witness, expr_path) = asset_router.serve_asset(&http_request).unwrap();
 
-Some additional steps are then required to prepare the response for sending:
+// this should normally be retrieved using `ic_cdk::api::data_certificate()`.
+let data_certificate = vec![1, 2, 3];
 
-- get the canister's certificate data
-- CBOR-encode the witness
-- CBOR-encode the expression path
-- Add the certificate header to the response
-
-```rust
-const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
-fn add_certificate_header(response: &mut HttpResponse, witness: &HashTree, expr_path: &[String]) {
-    let certified_data = data_certificate().expect("No data certificate available");
-    let witness = cbor_encode(witness);
-    let expr_path = cbor_encode(&expr_path);
-
-    response.headers.push((
-        IC_CERTIFICATE_HEADER.to_string(),
-        format!(
-            "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
-            BASE64.encode(certified_data),
-            BASE64.encode(witness),
-            BASE64.encode(expr_path)
-        ),
-    ));
-}
-
-// Encoding
-fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
-    let mut serializer = serde_cbor::Serializer::new(Vec::new());
-    serializer
-        .self_describe()
-        .expect("Failed to self describe CBOR");
-    value
-        .serialize(&mut serializer)
-        .expect("Failed to serialize value");
-    serializer.into_inner()
-}
-
-add_certificate_header(&mut response, &witness, &expr_path);
+add_certificate_header(
+    data_certificate,
+    &mut response,
+    &witness,
+    &expr_path,
+);
 ```
 
 ## Deleting assets

--- a/packages/ic-asset-certification/README.md
+++ b/packages/ic-asset-certification/README.md
@@ -460,7 +460,7 @@ This method will return a response, a witness and an expression path, which can 
 alongside the canister's data certificate to add the required certificate header to the response.
 
 ```rust
-use ic_http_certification::{HttpRequest, utils::add_certificate_header};
+use ic_http_certification::{HttpRequest, utils::add_v2_certificate_header};
 use ic_asset_certification::{Asset, AssetConfig, AssetFallbackConfig, AssetRouter};
 
 let mut asset_router = AssetRouter::default();
@@ -492,7 +492,7 @@ let (mut response, witness, expr_path) = asset_router.serve_asset(&http_request)
 // this should normally be retrieved using `ic_cdk::api::data_certificate()`.
 let data_certificate = vec![1, 2, 3];
 
-add_certificate_header(
+add_v2_certificate_header(
     data_certificate,
     &mut response,
     &witness,

--- a/packages/ic-asset-certification/src/asset_router.rs
+++ b/packages/ic-asset-certification/src/asset_router.rs
@@ -6,7 +6,7 @@ use ic_certification::HashTree;
 use ic_http_certification::{
     DefaultCelBuilder, DefaultResponseCertification, Hash, HttpCertification,
     HttpCertificationPath, HttpCertificationTree, HttpCertificationTreeEntry, HttpRequest,
-    HttpResponse,
+    HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
 };
 use std::{borrow::Cow, cell::RefCell, collections::HashMap, rc::Rc};
 
@@ -136,8 +136,6 @@ fn request_key(path: &str, encoding: Option<String>) -> RequestKey {
         encoding,
     }
 }
-
-const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
 
 fn encoding_str(maybe_encoding: Option<AssetEncoding>) -> Option<String> {
     maybe_encoding.map(|enc| enc.to_string())
@@ -725,7 +723,7 @@ impl<'content> AssetRouter<'content> {
             ))
             .build();
         let cel_expr_str = cel_expr.to_string();
-        headers.push((IC_CERTIFICATE_EXPRESSION_HEADER.to_string(), cel_expr_str));
+        headers.push((CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr_str));
 
         let request = HttpRequest::get(url).build();
 
@@ -1945,7 +1943,7 @@ mod tests {
                 ("content-length".to_string(), "0".to_string()),
                 ("location".to_string(), "/css/app-ba74b708.css".to_string()),
                 (
-                    IC_CERTIFICATE_EXPRESSION_HEADER.to_string(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                     cel_expr.clone(),
                 ),
             ])
@@ -1955,7 +1953,7 @@ mod tests {
             .with_headers(vec![
                 ("content-length".to_string(), "0".to_string()),
                 ("location".to_string(), "/".to_string()),
-                (IC_CERTIFICATE_EXPRESSION_HEADER.to_string(), cel_expr),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
             ])
             .build();
 
@@ -2454,7 +2452,7 @@ mod tests {
             .into_iter()
             .chain(vec![
                 ("content-length".to_string(), body.len().to_string()),
-                (IC_CERTIFICATE_EXPRESSION_HEADER.to_string(), cel_expr),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
             ])
             .collect();
 

--- a/packages/ic-asset-certification/src/lib.rs
+++ b/packages/ic-asset-certification/src/lib.rs
@@ -454,10 +454,11 @@
 //! ## Serving assets
 //!
 //! Assets can be served by calling the `serve_asset` method on the `AssetRouter`.
-//! This method will return a response, a witness and an expression path.
+//! This method will return a response, a witness and an expression path, which can be used
+//! alongside the canister's data certificate to add the required certificate header to the response.
 //!
 //! ```rust
-//! use ic_http_certification::HttpRequest;
+//! use ic_http_certification::{HttpRequest, utils::add_certificate_header};
 //! use ic_asset_certification::{Asset, AssetConfig, AssetFallbackConfig, AssetRouter};
 //!
 //! let mut asset_router = AssetRouter::default();
@@ -485,47 +486,16 @@
 //! asset_router.certify_assets(vec![asset], vec![asset_config]).unwrap();
 //!
 //! let (mut response, witness, expr_path) = asset_router.serve_asset(&http_request).unwrap();
-//! ```
 //!
-//! Some additional steps are then required to prepare the response for sending:
-//!
-//! - get the canister's certificate data
-//! - CBOR-encode the witness
-//! - CBOR-encode the expression path
-//! - Add the certificate header to the response
-//!
-//! ```ignore
-//! const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
-//! fn add_certificate_header(response: &mut HttpResponse, witness: &HashTree, expr_path: &[String]) {
-//!     let certified_data = data_certificate().expect("No data certificate available");
-//!     let witness = cbor_encode(witness);
-//!     let expr_path = cbor_encode(&expr_path);
-//!
-//!     response.headers.push((
-//!         IC_CERTIFICATE_HEADER.to_string(),
-//!         format!(
-//!             "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
-//!             BASE64.encode(certified_data),
-//!             BASE64.encode(witness),
-//!             BASE64.encode(expr_path)
-//!         ),
-//!     ));
-//! }
-//!
-//! // Encoding
-//! fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
-//!     let mut serializer = serde_cbor::Serializer::new(Vec::new());
-//!     serializer
-//!         .self_describe()
-//!         .expect("Failed to self describe CBOR");
-//!     value
-//!         .serialize(&mut serializer)
-//!         .expect("Failed to serialize value");
-//!     serializer.into_inner()
-//! }
-//!
-//! add_certificate_header(&mut response, &witness, &expr_path);
-//! ```
+//! // this should normally be retrieved using `ic_cdk::api::data_certificate()`.
+//! let data_certificate = vec![1, 2, 3];
+//! add_certificate_header(
+//!     data_certificate,
+//!     &mut response,
+//!     &witness,
+//!     &expr_path,
+//! );
+//!```
 //!
 //! ## Deleting assets
 //!

--- a/packages/ic-asset-certification/src/lib.rs
+++ b/packages/ic-asset-certification/src/lib.rs
@@ -458,7 +458,7 @@
 //! alongside the canister's data certificate to add the required certificate header to the response.
 //!
 //! ```rust
-//! use ic_http_certification::{HttpRequest, utils::add_certificate_header};
+//! use ic_http_certification::{HttpRequest, utils::add_v2_certificate_header};
 //! use ic_asset_certification::{Asset, AssetConfig, AssetFallbackConfig, AssetRouter};
 //!
 //! let mut asset_router = AssetRouter::default();
@@ -489,7 +489,7 @@
 //!
 //! // this should normally be retrieved using `ic_cdk::api::data_certificate()`.
 //! let data_certificate = vec![1, 2, 3];
-//! add_certificate_header(
+//! add_v2_certificate_header(
 //!     data_certificate,
 //!     &mut response,
 //!     &witness,

--- a/packages/ic-certification/Cargo.toml
+++ b/packages/ic-certification/Cargo.toml
@@ -32,4 +32,5 @@ serde_cbor.workspace = true
 rstest.workspace = true
 
 [features]
-default = ['serde', 'serde_bytes']
+serde = ['dep:serde', 'dep:serde_bytes']
+default = ['serde']

--- a/packages/ic-http-certification-tests/tests/v1_response_verification.rs
+++ b/packages/ic-http-certification-tests/tests/v1_response_verification.rs
@@ -1,7 +1,7 @@
 mod tests {
     use ic_certificate_verification::CertificateVerificationError;
     use ic_certification_testing::{CertificateBuilder, CertificateData};
-    use ic_http_certification::{HttpRequest, HttpResponse};
+    use ic_http_certification::{HttpRequest, HttpResponse, CERTIFICATE_HEADER_NAME};
     use ic_response_verification::types::{VerificationInfo, VerifiedResponse};
     use ic_response_verification::verify_request_response_pair;
     use ic_response_verification::ResponseVerificationError;
@@ -44,7 +44,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
         let expected_response = VerifiedResponse {
             status_code: None,
@@ -102,7 +102,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
         let expected_response = VerifiedResponse {
             status_code: None,
@@ -159,7 +159,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
         let expected_response = VerifiedResponse {
             status_code: None,
@@ -216,7 +216,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(b"Hello IC!")
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -265,7 +265,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -318,7 +318,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -373,7 +373,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -426,7 +426,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -476,7 +476,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -524,7 +524,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(
@@ -572,7 +572,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_body(body.as_bytes())
-            .with_headers(vec![("IC-Certificate".into(), certificate_header)])
+            .with_headers(vec![(CERTIFICATE_HEADER_NAME.into(), certificate_header)])
             .build();
 
         let result = verify_request_response_pair(

--- a/packages/ic-http-certification-tests/tests/v2_response_verification_certification_scenarios.rs
+++ b/packages/ic-http-certification-tests/tests/v2_response_verification_certification_scenarios.rs
@@ -15,7 +15,7 @@ mod tests {
     };
     use ic_http_certification::{
         HttpCertificationPath, HttpCertificationTree, HttpCertificationTreeEntry, HttpRequest,
-        HttpResponse,
+        HttpResponse, CERTIFICATE_HEADER_NAME,
     };
     use ic_response_verification::{
         types::{VerificationInfo, VerifiedResponse},
@@ -83,7 +83,10 @@ mod tests {
             .map(|(key, value)| (key.to_lowercase(), String::from(value)))
             .collect::<Vec<_>>()
             .clone();
-        expected_headers.push(("IC-Certificate".to_string(), certificate_header.clone()));
+        expected_headers.push((
+            CERTIFICATE_HEADER_NAME.to_string(),
+            certificate_header.clone(),
+        ));
 
         let expected_certified_response = VerifiedResponse {
             body: expected_response.body().to_vec(),
@@ -91,7 +94,7 @@ mod tests {
             status_code: Some(expected_response.status_code()),
         };
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -150,7 +153,7 @@ mod tests {
             ),
         );
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -205,7 +208,7 @@ mod tests {
             ),
         );
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -272,7 +275,7 @@ mod tests {
             ),
         );
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -327,7 +330,7 @@ mod tests {
             ),
         );
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -391,7 +394,10 @@ mod tests {
             .map(|(key, value)| (key.to_lowercase(), String::from(value)))
             .collect::<Vec<_>>()
             .clone();
-        expected_headers.push(("IC-Certificate".to_string(), certificate_header.clone()));
+        expected_headers.push((
+            CERTIFICATE_HEADER_NAME.to_string(),
+            certificate_header.clone(),
+        ));
 
         let expected_certified_response = VerifiedResponse {
             body: expected_response.body().to_vec(),
@@ -399,7 +405,7 @@ mod tests {
             status_code: Some(expected_response.status_code()),
         };
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -447,7 +453,7 @@ mod tests {
             ),
         );
 
-        expected_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        expected_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -472,6 +478,7 @@ mod fixtures {
         DefaultCelBuilder, DefaultFullCelExpression, DefaultResponseCertification,
         DefaultResponseOnlyCelExpression, HttpCertification, HttpCertificationPath,
         HttpCertificationTree, HttpCertificationTreeEntry, HttpRequest, HttpResponse,
+        CERTIFICATE_EXPRESSION_HEADER_NAME,
     };
     use ic_response_verification_test_utils::{deflate_encode, gzip_encode, hash};
     use rstest::*;
@@ -494,7 +501,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/html".into()),
                 ("Content-Encoding".into(), "gzip".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -518,7 +525,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/javascript".into()),
                 ("Content-Encoding".into(), "gzip".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -542,7 +549,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/plain".into()),
                 ("Content-Encoding".into(), "identity".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -565,7 +572,7 @@ mod fixtures {
             .with_body(body)
             .with_headers(vec![
                 ("Location".into(), "/new-path".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -588,7 +595,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/html".into()),
                 ("Content-Encoding".into(), "identity".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -616,7 +623,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/html".into()),
                 ("Content-Encoding".into(), "gzip".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -640,7 +647,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/html".into()),
                 ("Content-Encoding".into(), "deflate".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -682,7 +689,7 @@ mod fixtures {
             .with_headers(vec![
                 ("Content-Type".into(), "text/html".into()),
                 ("Content-Encoding".into(), "deflate".into()),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }
@@ -729,7 +736,7 @@ mod fixtures {
                 ("Content-Type".into(), "text/html".into()),
                 ("Content-Encoding".into(), "deflate".into()),
                 ("ETag".into(), etag),
-                ("IC-CertificateExpression".into(), cel.to_string()),
+                (CERTIFICATE_EXPRESSION_HEADER_NAME.into(), cel.to_string()),
             ])
             .build()
     }

--- a/packages/ic-http-certification-tests/tests/v2_response_verification_happy_path.rs
+++ b/packages/ic-http-certification-tests/tests/v2_response_verification_happy_path.rs
@@ -1,7 +1,8 @@
 mod tests {
     use ic_http_certification::{
         DefaultCelBuilder, DefaultResponseCertification, HttpCertification, HttpCertificationPath,
-        HttpCertificationTreeEntry, HttpRequest, HttpResponse,
+        HttpCertificationTreeEntry, HttpRequest, HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
+        CERTIFICATE_HEADER_NAME,
     };
     use ic_response_verification::{
         types::{VerificationInfo, VerifiedResponse},
@@ -27,7 +28,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
@@ -42,7 +46,7 @@ mod tests {
             canister_id,
         } = create_v2_fixture(req_path, &certification_tree_entry, &current_time);
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header));
+        response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -82,7 +86,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
@@ -97,7 +104,10 @@ mod tests {
             canister_id,
         } = create_v2_fixture(req_path, &certification_tree_entry, &current_time);
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header.clone()));
+        response.add_header((
+            CERTIFICATE_HEADER_NAME.to_string(),
+            certificate_header.clone(),
+        ));
 
         let result = verify_request_response_pair(
             request,
@@ -114,9 +124,12 @@ mod tests {
             status_code: Some(200),
             body: body.as_bytes().to_vec(),
             headers: vec![
-                ("ic-certificateexpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_lowercase(),
+                    cel_expr.to_string(),
+                ),
                 ("cache-control".into(), "max-age=604800".into()),
-                ("IC-Certificate".into(), certificate_header),
+                (CERTIFICATE_HEADER_NAME.into(), certificate_header),
             ],
         };
 
@@ -154,7 +167,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
@@ -169,7 +185,10 @@ mod tests {
             canister_id,
         } = create_v2_fixture(req_path, &certification_tree_entry, &current_time);
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header.clone()));
+        response.add_header((
+            CERTIFICATE_HEADER_NAME.to_string(),
+            certificate_header.clone(),
+        ));
 
         let result = verify_request_response_pair(
             request,
@@ -186,9 +205,12 @@ mod tests {
             status_code: Some(200),
             body: body.as_bytes().to_vec(),
             headers: vec![
-                ("ic-certificateexpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_lowercase(),
+                    cel_expr.to_string(),
+                ),
                 ("cache-control".into(), "max-age=604800".into()),
-                ("IC-Certificate".into(), certificate_header),
+                (CERTIFICATE_HEADER_NAME.into(), certificate_header),
             ],
         };
 
@@ -219,7 +241,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
                 ("Content-Encoding".into(), "gzip".into()),
                 ("Content-Language".into(), "en-US".into()),
@@ -236,7 +261,10 @@ mod tests {
             canister_id,
         } = create_v2_fixture(req_path, &certification_tree_entry, &current_time);
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header.clone()));
+        response.add_header((
+            CERTIFICATE_HEADER_NAME.to_string(),
+            certificate_header.clone(),
+        ));
 
         let result = verify_request_response_pair(
             request,
@@ -253,10 +281,13 @@ mod tests {
             status_code: Some(200),
             body: body.as_bytes().to_vec(),
             headers: vec![
-                ("ic-certificateexpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_lowercase(),
+                    cel_expr.to_string(),
+                ),
                 ("cache-control".into(), "max-age=604800".into()),
                 ("server".into(), "Apache/2.4.1 (Unix)".into()),
-                ("IC-Certificate".into(), certificate_header),
+                (CERTIFICATE_HEADER_NAME.into(), certificate_header),
             ],
         };
 

--- a/packages/ic-http-certification-tests/tests/v2_response_verification_sad_path.rs
+++ b/packages/ic-http-certification-tests/tests/v2_response_verification_sad_path.rs
@@ -8,7 +8,8 @@ mod tests {
     use ic_certificate_verification::CertificateVerificationError;
     use ic_http_certification::{
         CelExpression, DefaultFullCelExpression, HttpCertification, HttpCertificationPath,
-        HttpCertificationTreeEntry, HttpRequest, HttpResponse,
+        HttpCertificationTreeEntry, HttpRequest, HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
+        CERTIFICATE_HEADER_NAME,
     };
     use ic_response_verification::{verify_request_response_pair, ResponseVerificationError};
     use ic_response_verification_test_utils::{
@@ -42,7 +43,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
@@ -57,7 +61,7 @@ mod tests {
             canister_id,
         } = create_v2_fixture(req_path, &certification_tree_entry, &current_time);
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header));
+        response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             wrong_request,
@@ -94,7 +98,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
@@ -102,7 +109,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "public".into()),
                 ("Cache-Control".into(), "immutable".into()),
             ])
@@ -118,7 +128,7 @@ mod tests {
             canister_id,
         } = create_v2_fixture(req_path, &certification_tree_entry, &current_time);
 
-        wrong_response.add_header(("IC-Certificate".to_string(), certificate_header));
+        wrong_response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,
@@ -156,7 +166,10 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
@@ -177,11 +190,11 @@ mod tests {
         let certificate_header =
             create_v2_header(&certification_tree_entry, &certificate_cbor, &tree_cbor);
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header));
+        response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
         let _ = std::mem::replace(
             &mut response.headers_mut()[0],
             (
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 wrong_cel_expr.to_string(),
             ),
         );
@@ -244,12 +257,15 @@ mod tests {
             .with_status_code(200)
             .with_body(body.as_bytes())
             .with_headers(vec![
-                ("IC-CertificateExpression".into(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                    cel_expr.to_string(),
+                ),
                 ("Cache-Control".into(), "max-age=604800".into()),
             ])
             .build();
 
-        response.add_header(("IC-Certificate".to_string(), certificate_header));
+        response.add_header((CERTIFICATE_HEADER_NAME.to_string(), certificate_header));
 
         let result = verify_request_response_pair(
             request,

--- a/packages/ic-http-certification/Cargo.toml
+++ b/packages/ic-http-certification/Cargo.toml
@@ -14,17 +14,16 @@ repository.workspace = true
 license.workspace = true
 homepage.workspace = true
 
-[features]
-serde = ["ic-certification/serde", "ic-certification/serde_bytes"]
-
 [dependencies]
 candid.workspace = true
 serde.workspace = true
 http.workspace = true
 urlencoding.workspace = true
 ic-representation-independent-hash.workspace = true
-ic-certification.workspace = true
+ic-certification = { workspace = true, features = ["serde"] }
 thiserror.workspace = true
+base64.workspace = true
+serde_cbor.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/packages/ic-http-certification/src/hash/response_hash.rs
+++ b/packages/ic-http-certification/src/hash/response_hash.rs
@@ -175,7 +175,7 @@ mod tests {
             response_headers.headers,
             vec![
                 (
-                    "ic-certificateexpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_lowercase(),
                     remove_whitespace(CERTIFIED_HEADERS_CEL_EXPRESSION),
                 ),
                 ("accept-encoding".into(), "gzip".into()),
@@ -197,7 +197,7 @@ mod tests {
             response_headers.headers,
             vec![
                 (
-                    "ic-certificateexpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_lowercase(),
                     remove_whitespace(CERTIFIED_HEADERS_CEL_EXPRESSION),
                 ),
                 ("accept-encoding".into(), "gzip".into()),
@@ -233,7 +233,7 @@ mod tests {
             .with_status_code(200)
             .with_headers(vec![
                 (
-                    "IC-CertificateExpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                     remove_whitespace(CERTIFIED_HEADERS_CEL_EXPRESSION),
                 ),
                 ("Accept-Encoding".into(), "gzip".into()),
@@ -279,7 +279,7 @@ mod tests {
             .with_status_code(200)
             .with_headers(vec![
                 (
-                    "IC-CertificateExpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                     remove_whitespace(HEADER_EXCLUSIONS_CEL_EXPRESSION),
                 ),
                 ("Accept-Encoding".into(), "gzip".into()),
@@ -325,9 +325,9 @@ mod tests {
         let response_without_excluded_headers = HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![
-                ("IC-Certificate".into(), CERTIFICATE.into()),
+                (CERTIFICATE_HEADER_NAME.into(), CERTIFICATE.into()),
                 (
-                    "IC-CertificateExpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                     remove_whitespace(CERTIFIED_HEADERS_CEL_EXPRESSION),
                 ),
                 ("Accept-Encoding".into(), "gzip".into()),
@@ -375,9 +375,9 @@ mod tests {
         let response_without_excluded_headers = HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![
-                ("IC-Certificate".into(), CERTIFICATE.into()),
+                (CERTIFICATE_HEADER_NAME.into(), CERTIFICATE.into()),
                 (
-                    "IC-CertificateExpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                     remove_whitespace(HEADER_EXCLUSIONS_CEL_EXPRESSION),
                 ),
                 ("Accept-Encoding".into(), "gzip".into()),
@@ -426,9 +426,9 @@ mod tests {
         HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![
-                ("IC-Certificate".into(), CERTIFICATE.into()),
+                (CERTIFICATE_HEADER_NAME.into(), CERTIFICATE.into()),
                 (
-                    "IC-CertificateExpression".into(),
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                     remove_whitespace(cel_expression),
                 ),
                 ("Accept-Encoding".into(), "gzip".into()),

--- a/packages/ic-http-certification/src/lib.rs
+++ b/packages/ic-http-certification/src/lib.rs
@@ -190,7 +190,7 @@ To perform a full certification, a CEL expression created from [DefaultCelBuilde
 For example:
 
 ```rust
-use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
+use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, CERTIFICATE_EXPRESSION_HEADER_NAME};
 
 let cel_expr = DefaultCelBuilder::full_certification()
     .with_request_headers(vec!["Accept", "Accept-Encoding", "If-None-Match"])
@@ -214,7 +214,7 @@ let response = HttpResponse::builder()
     .with_headers(vec![
         ("Cache-Control".to_string(), "no-cache".to_string()),
         ("ETag".to_string(), "123456789".to_string()),
-        ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
+        (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr.to_string()),
     ])
     .with_body(vec![1, 2, 3, 4, 5, 6])
     .build();
@@ -229,7 +229,7 @@ To perform a response-only certification, a CEL expression created from [Default
 For example:
 
 ```rust
-use ic_http_certification::{HttpCertification, HttpResponse, DefaultCelBuilder, DefaultResponseCertification};
+use ic_http_certification::{HttpCertification, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, CERTIFICATE_EXPRESSION_HEADER_NAME};
 
 let cel_expr = DefaultCelBuilder::response_only_certification()
     .with_response_certification(DefaultResponseCertification::certified_response_headers(vec![
@@ -243,7 +243,7 @@ let response = HttpResponse::builder()
     .with_headers(vec![
         ("Cache-Control".to_string(), "no-cache".to_string()),
         ("ETag".to_string(), "123456789".to_string()),
-        ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
+        (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr.to_string()),
     ])
     .with_body(vec![1, 2, 3, 4, 5, 6])
     .build();
@@ -296,7 +296,7 @@ The [HttpCertificationTree] can be easily initialized with the [Default] trait a
 For example:
 
 ```rust
-use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, HttpCertificationTree, HttpCertificationTreeEntry, HttpCertificationPath};
+use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, HttpCertificationTree, HttpCertificationTreeEntry, HttpCertificationPath, CERTIFICATE_EXPRESSION_HEADER_NAME};
 
 let cel_expr = DefaultCelBuilder::full_certification()
     .with_request_headers(vec!["Accept", "Accept-Encoding", "If-None-Match"])
@@ -320,7 +320,7 @@ let response = HttpResponse::builder()
     .with_headers(vec![
         ("Cache-Control".to_string(), "no-cache".to_string()),
         ("ETag".to_string(), "123456789".to_string()),
-        ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
+        (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr.to_string()),
     ])
     .with_body(vec![1, 2, 3, 4, 5, 6])
     .build();

--- a/packages/ic-http-certification/src/tree/certification.rs
+++ b/packages/ic-http-certification/src/tree/certification.rs
@@ -1,7 +1,7 @@
 use crate::{
     request_hash, response_hash, DefaultCelBuilder, DefaultFullCelExpression,
     DefaultResponseOnlyCelExpression, HttpCertificationError, HttpCertificationResult, HttpRequest,
-    HttpResponse,
+    HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
 };
 use ic_certification::Hash;
 use ic_representation_independent_hash::hash;
@@ -117,7 +117,7 @@ impl HttpCertification {
         let mut found_header = false;
 
         for (header_name, header_value) in response.headers() {
-            if header_name.to_lowercase() == "ic-certificateexpression" {
+            if header_name.to_lowercase() == CERTIFICATE_EXPRESSION_HEADER_NAME.to_lowercase() {
                 match header_value == cel_expr {
                     true => {
                         if found_header {
@@ -196,7 +196,7 @@ mod tests {
         let response = &HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![(
-                "IC-CertificateExpression".to_string(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -252,7 +252,7 @@ mod tests {
         let response = &HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![(
-                "IC-CertificateExpression".to_string(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                 wrong_cel_expr.to_string(),
             )])
             .build();
@@ -277,8 +277,14 @@ mod tests {
         let response = &HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![
-                ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
-                ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+                    cel_expr.to_string(),
+                ),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+                    cel_expr.to_string(),
+                ),
             ])
             .build();
 
@@ -307,7 +313,7 @@ mod tests {
         let response = &HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![(
-                "IC-CertificateExpression".to_string(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -373,7 +379,7 @@ mod tests {
         let response = &HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![(
-                "IC-CertificateExpression".to_string(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                 wrong_cel_expr.to_string(),
             )])
             .build();
@@ -403,8 +409,14 @@ mod tests {
         let response = &HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![
-                ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
-                ("IC-CertificateExpression".to_string(), cel_expr.to_string()),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+                    cel_expr.to_string(),
+                ),
+                (
+                    CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+                    cel_expr.to_string(),
+                ),
             ])
             .build();
         let result = HttpCertification::full(&cel_expr, request, response, None).unwrap_err();

--- a/packages/ic-http-certification/src/tree/certification_tree.rs
+++ b/packages/ic-http-certification/src/tree/certification_tree.rs
@@ -102,7 +102,7 @@ mod tests {
     use super::*;
     use crate::{
         DefaultCelBuilder, DefaultResponseCertification, HttpCertification, HttpRequest,
-        HttpResponse,
+        HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
     };
     use ic_certification::SubtreeLookupResult;
     use rstest::*;
@@ -122,7 +122,7 @@ mod tests {
             .with_status_code(404)
             .with_body(br#"404 Not Found"#)
             .with_headers(vec![(
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -132,7 +132,7 @@ mod tests {
             .with_status_code(404)
             .with_body(br#"console.log("Hello, World!")"#)
             .with_headers(vec![(
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -230,7 +230,7 @@ mod tests {
             .with_status_code(200)
             .with_body(br#"console.log("Hello, World!")"#)
             .with_headers(vec![(
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -238,7 +238,7 @@ mod tests {
             .with_status_code(200)
             .with_body(br#"console.log("Hello, ALT World!")"#)
             .with_headers(vec![(
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -480,7 +480,7 @@ mod tests {
             .with_status_code(404)
             .with_body(br#"404 Not Found"#)
             .with_headers(vec![(
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -517,7 +517,7 @@ mod tests {
             .with_status_code(200)
             .with_body(index_html_body)
             .with_headers(vec![(
-                "IC-CertificateExpression".into(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
                 cel_expr.to_string(),
             )])
             .build();

--- a/packages/ic-http-certification/src/tree/certification_tree_entry.rs
+++ b/packages/ic-http-certification/src/tree/certification_tree_entry.rs
@@ -54,7 +54,7 @@ mod tests {
     use super::*;
     use crate::{
         request_hash, response_hash, DefaultCelBuilder, DefaultResponseCertification, HttpRequest,
-        HttpResponse,
+        HttpResponse, CERTIFICATE_EXPRESSION_HEADER_NAME,
     };
     use ic_representation_independent_hash::hash;
     use rstest::*;
@@ -111,7 +111,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![(
-                "IC-CertificateExpression".to_string(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                 cel_expr.to_string(),
             )])
             .build();
@@ -154,7 +154,7 @@ mod tests {
         let response = HttpResponse::builder()
             .with_status_code(200)
             .with_headers(vec![(
-                "IC-CertificateExpression".to_string(),
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
                 cel_expr.to_string(),
             )])
             .build();

--- a/packages/ic-http-certification/src/utils/mod.rs
+++ b/packages/ic-http-certification/src/utils/mod.rs
@@ -4,3 +4,6 @@
 
 mod wildcard_paths;
 pub use wildcard_paths::*;
+
+mod response_header;
+pub use response_header::*;

--- a/packages/ic-http-certification/src/utils/response_header.rs
+++ b/packages/ic-http-certification/src/utils/response_header.rs
@@ -1,0 +1,95 @@
+use crate::{HttpResponse, CERTIFICATE_HEADER_NAME};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use ic_certification::HashTree;
+use serde::Serialize;
+
+/// Adds the `IC-Certificate` header to a given [`HttpResponse`]. This header is used by the HTTP Gateway
+/// to verify the authenticity of query call responses.
+///
+/// # Arguments
+///
+/// * `data_certificate` - A certificate used by the HTTP Gateway to verify a response.
+///     Retrieved using `ic_cdk::api::data_certificate`.
+/// * `response` - The [`HttpResponse`] to add the certificate header to.
+///     Created using [`HttpResponse::builder()`](crate::HttpResponse::builder).
+/// * `witness` - A pruned merkle tree revealing the relevant certification for the current response.
+///     Created using [`HttpCertificationTree::witness()`](crate::HttpCertificationTree::witness).
+/// * `expr_path` - An expression path for the current response informing the HTTP Gateway where the
+///     relevant certification is present in the merkle tree. Created using
+///     [`HttpCertificationPath::to_expr_path()`](crate::HttpCertificationPath::to_expr_path).
+///
+/// # Example
+///
+/// ```
+/// use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, HttpCertificationTree, HttpCertificationTreeEntry, HttpCertificationPath, CERTIFICATE_EXPRESSION_HEADER_NAME, CERTIFICATE_HEADER_NAME, utils::add_certificate_header};
+///
+/// let cel_expr = DefaultCelBuilder::full_certification().build();
+///
+/// let request = HttpRequest::get("/index.html?foo=a&bar=b&baz=c").build();
+///
+/// let mut response = HttpResponse::builder()
+///     .with_headers(vec![(CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr.to_string())])
+///     .build();
+///
+/// let request_url = "/example.json";
+/// let path = HttpCertificationPath::exact(request_url);
+/// let expr_path = path.to_expr_path();
+///
+/// let certification = HttpCertification::full(&cel_expr, &request, &response, None).unwrap();
+/// let entry = HttpCertificationTreeEntry::new(&path, &certification);
+///
+/// let mut http_certification_tree = HttpCertificationTree::default();
+/// http_certification_tree.insert(&entry);
+///
+/// // this should normally be retrieved using `ic_cdk::api::data_certificate()`.
+/// let data_certificate = vec![1, 2, 3];
+///
+/// let witness = http_certification_tree.witness(&entry, request_url).unwrap();
+/// add_certificate_header(
+///     data_certificate,
+///     &mut response,
+///     &witness,
+///     &expr_path
+/// );
+///
+/// assert_eq!(
+///     response.headers(),
+///     vec![
+///         (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr.to_string()),
+///         (
+///             CERTIFICATE_HEADER_NAME.to_string(),
+///             "certificate=:AQID:, tree=:2dn3gwJJaHR0cF9leHBygwJMZXhhbXBsZS5qc29ugwJDPCQ+gwJYIFJ2k+R/YYbgGPADidRdRwDurH06HXACVHlTIVrv1q4WgwJYIPZhxTCrVVSCuQKpNIckLOog7Q9SpfZ/0AODejmxpJ7egwJYIM7zUx3VibIaHEUF14Kx813l3Xlilg43Y5uGaABAA/i9ggNA:, expr_path=:2dn3g2lodHRwX2V4cHJsZXhhbXBsZS5qc29uYzwkPg==:, version=2".to_string(),
+///         ),
+///     ]
+/// );
+/// ```
+pub fn add_certificate_header(
+    data_certificate: Vec<u8>,
+    response: &mut HttpResponse,
+    witness: &HashTree,
+    expr_path: &[String],
+) {
+    let witness = cbor_encode(witness);
+    let expr_path = cbor_encode(&expr_path);
+
+    response.add_header((
+        CERTIFICATE_HEADER_NAME.to_string(),
+        format!(
+            "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+            BASE64.encode(data_certificate),
+            BASE64.encode(witness),
+            BASE64.encode(expr_path)
+        ),
+    ));
+}
+
+fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
+    let mut serializer = serde_cbor::Serializer::new(Vec::new());
+    serializer
+        .self_describe()
+        .expect("Failed to self describe CBOR");
+    value
+        .serialize(&mut serializer)
+        .expect("Failed to serialize value");
+    serializer.into_inner()
+}

--- a/packages/ic-http-certification/src/utils/response_header.rs
+++ b/packages/ic-http-certification/src/utils/response_header.rs
@@ -3,25 +3,31 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use ic_certification::HashTree;
 use serde::Serialize;
 
-/// Adds the `IC-Certificate` header to a given [`HttpResponse`]. This header is used by the HTTP Gateway
-/// to verify the authenticity of query call responses.
+/// Adds the [`IC-Certificate` header](https://internetcomputer.org/docs/current/references/http-gateway-protocol-spec/#the-certificate-header)
+/// to a given [`HttpResponse`]. This header is used by the HTTP Gateway to verify the authenticity of query call responses made to the
+/// `http_request` method of the target canister.
 ///
 /// # Arguments
 ///
 /// * `data_certificate` - A certificate used by the HTTP Gateway to verify a response.
-///     Retrieved using `ic_cdk::api::data_certificate`.
+///     Retrieved using `ic_cdk::api::data_certificate`. This value is not validated by this function
+///     and is expected to be a valid certificate. The function will not fail if the certificate is invalid,
+///     but verification of the certificate by the HTTP Gateway will fail.
 /// * `response` - The [`HttpResponse`] to add the certificate header to.
 ///     Created using [`HttpResponse::builder()`](crate::HttpResponse::builder).
 /// * `witness` - A pruned merkle tree revealing the relevant certification for the current response.
 ///     Created using [`HttpCertificationTree::witness()`](crate::HttpCertificationTree::witness).
+///     The witness is not validated to be correct for the given response, and the function will not fail
+///     if the witness is invalid. The HTTP Gateway will fail to verify the response if the witness is invalid.
 /// * `expr_path` - An expression path for the current response informing the HTTP Gateway where the
 ///     relevant certification is present in the merkle tree. Created using
-///     [`HttpCertificationPath::to_expr_path()`](crate::HttpCertificationPath::to_expr_path).
+///     [`HttpCertificationPath::to_expr_path()`](crate::HttpCertificationPath::to_expr_path). The expression path
+///     is not validated to be correct for the given response, and the function will not fail if the expression path is invalid.
 ///
 /// # Example
 ///
 /// ```
-/// use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, HttpCertificationTree, HttpCertificationTreeEntry, HttpCertificationPath, CERTIFICATE_EXPRESSION_HEADER_NAME, CERTIFICATE_HEADER_NAME, utils::add_certificate_header};
+/// use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, HttpCertificationTree, HttpCertificationTreeEntry, HttpCertificationPath, CERTIFICATE_EXPRESSION_HEADER_NAME, CERTIFICATE_HEADER_NAME, utils::add_v2_certificate_header};
 ///
 /// let cel_expr = DefaultCelBuilder::full_certification().build();
 ///
@@ -45,7 +51,7 @@ use serde::Serialize;
 /// let data_certificate = vec![1, 2, 3];
 ///
 /// let witness = http_certification_tree.witness(&entry, request_url).unwrap();
-/// add_certificate_header(
+/// add_v2_certificate_header(
 ///     data_certificate,
 ///     &mut response,
 ///     &witness,
@@ -63,7 +69,7 @@ use serde::Serialize;
 ///     ]
 /// );
 /// ```
-pub fn add_certificate_header(
+pub fn add_v2_certificate_header(
     data_certificate: Vec<u8>,
     response: &mut HttpResponse,
     witness: &HashTree,


### PR DESCRIPTION
removed serde feature from ic-http-certification, condensed serde_bytes into serde feature of ic-certification

BREAKING CHANGE: removed serde feature from ic-http-certification, condensed serde_bytes into serde feature of ic-certification.

TT-426