### PR TITLE
feat(ic-http-certification): add common constructs to skip certification

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,6 +68,20 @@ jobs:
           dfx generate backend
           dfx build backend --check
 
+      - name: DFX prepare HTTP Certification Custom Assets
+        working-directory: examples/http-certification/custom-assets
+        run: |
+          dfx canister create backend
+          dfx generate backend
+          dfx build backend --check
+
+      - name: DFX prepare HTTP Certification Skip Certification
+        working-directory: examples/http-certification/skip-certification
+        run: |
+          dfx canister create backend
+          dfx generate backend
+          dfx build backend --check
+
       - name: Build NPM packages
         run: pnpm build
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ node_modules
 .DS_Store
 /tmp
 pkg
-Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .DS_Store
 /tmp
 pkg
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http_certification_skip_certification_backend"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-cdk",
+ "ic-http-certification",
+]
+
+[[package]]
 name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arrayvec"
@@ -266,9 +266,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cached"
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -3182,18 +3182,18 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -3605,9 +3605,9 @@ checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/http-certification/json-api/src/backend",
     "examples/http-certification/assets/src/backend",
     "examples/http-certification/custom-assets/src/backend",
+    "examples/http-certification/skip-certification/src/backend",
     "packages/ic-asset-certification",
     "packages/ic-cbor",
     "packages/ic-certification",

--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -144,7 +144,7 @@ The first step is defining a reusable function to create a response with all of 
 ```rust
 fn get_asset_headers(
     additional_headers: Vec<HeaderField>,
-    body: &[u8],
+    content_length: usize,
     cel_expr: String,
 ) -> Vec<(String, String)> {
     // set up the default headers and include additional headers provided by the caller
@@ -157,7 +157,7 @@ fn get_asset_headers(
         ("permissions-policy".to_string(), "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()".to_string()),
         ("cross-origin-embedder-policy".to_string(), "require-corp".to_string()),
         ("cross-origin-opener-policy".to_string(), "same-origin".to_string()),
-        ("content-length".to_string(), body.len().to_string()),
+        ("content-length".to_string(), content_length.to_string()),
         (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
     ];
     headers.extend(additional_headers);
@@ -170,7 +170,7 @@ fn create_asset_response(
     body: &[u8],
     cel_expr: String,
 ) -> HttpResponse {
-    let headers = get_asset_headers(additional_headers, body, cel_expr);
+    let headers = get_asset_headers(additional_headers, body.len(), cel_expr);
 
     HttpResponse::builder()
         .with_status_code(200)
@@ -386,19 +386,19 @@ fn certify_index_asset() {
 }
 ```
 
-It's also possible to skip certification for certain routes. This can be relatively easily as follows:
+It's also possible to skip certification for certain routes. This can be useful for scenarios where it's difficult to predict what the response will look like for a certain route and the content is not very security sensitive. This can be done as follows:
 
 ```rust
-const DYNAMIC_REQ_PATH: &str = "/dynamic";
+const UNCERTIFIED_REQ_PATH: &str = "/uncertified";
 
-fn certify_dynamic_asset() {
-    let dynamic_req_tree_path = HttpCertificationPath::exact(DYNAMIC_REQ_PATH);
-    let dynamic_req_certification = HttpCertification::skip();
+fn add_certification_skips() {
+    let uncertified_req_tree_path = HttpCertificationPath::exact(UNCERTIFIED_REQ_PATH);
+    let uncertified_req_certification = HttpCertification::skip();
 
     HTTP_TREE.with_borrow_mut(|http_tree| {
         http_tree.insert(&HttpCertificationTreeEntry::new(
-            dynamic_req_tree_path,
-            &dynamic_req_certification,
+            uncertified_req_tree_path,
+            &uncertified_req_certification,
         ));
     });
 }
@@ -418,7 +418,7 @@ With all of the above functions, it is now possible to certify all of the fronte
 
 ```rust
 fn certify_all_assets() {
-    certify_dynamic_asset();
+    add_certification_skips();
 
     certify_index_asset();
     certify_asset_glob("assets/**/*.css", "text/css");
@@ -434,8 +434,8 @@ fn certify_all_assets() {
 
 With all assets certified, they can be served over HTTP. The steps to follow when serving assets are:
 
-- Check if the request path matches the dynamic path.
-  - If the requested path exactly matches the dynamic path, serve the dynamic response.
+- Check if the request path matches the uncertified path.
+  - If the requested path exactly matches the uncertified path, serve the uncertified response.
 - Check if the requested path matches a file (e.g., `/assets/app.js`).
   - If the request path exactly matches an existing file, serve that file.
   - Otherwise, serve the `index.html` file.
@@ -452,13 +452,13 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     RESPONSES.with_borrow(|responses| {
         ENCODED_RESPONSES.with_borrow(|encoded_responses| {
             let (asset_req_path, asset_tree_path, identity_response) =
-            // if the request path matches the dynamic response's path, serve that
-            if req_path == DYNAMIC_REQ_PATH {
+            // if the request path matches the uncertified response's path, serve that
+            if req_path == UNCERTIFIED_REQ_PATH {
                 (
-                    DYNAMIC_REQ_PATH.to_string(),
-                    HttpCertificationPath::exact(DYNAMIC_REQ_PATH),
+                    UNCERTIFIED_REQ_PATH.to_string(),
+                    HttpCertificationPath::exact(UNCERTIFIED_REQ_PATH),
                     CertifiedHttpResponse {
-                        response: create_dynamic_response(),
+                        response: create_uncertified_response(),
                         certification: HttpCertification::skip(),
                     },
                 )
@@ -538,10 +538,10 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 }
 ```
 
-Creating the dynamic response is done as follows:
+Creating the uncertified response is done as follows:
 
 ```rust
-fn create_dynamic_response() -> HttpResponse<'static> {
+fn create_uncertified_response() -> HttpResponse<'static> {
     let body = format!(
         r#"
             <html>
@@ -564,7 +564,7 @@ fn create_dynamic_response() -> HttpResponse<'static> {
 
     let headers = get_asset_headers(
         additional_headers,
-        &body,
+        body.len(),
         DefaultCelBuilder::skip_certification().to_string(),
     );
 

--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -121,6 +121,7 @@ With the assets loaded, similar to the [JSON API](https://internetcomputer.org/d
 Encoded assets are stored in a separate `HashMap` to make routing easier. This will be more apparent later in this guide.
 
 ```rust
+#[derive(Clone)]
 struct CertifiedHttpResponse<'a> {
     response: HttpResponse<'a>,
     certification: HttpCertification,
@@ -141,11 +142,11 @@ Certifying responses is more involved here compared to the simpler approach used
 The first step is defining a reusable function to create a response with all of the necessary default headers. This function is very similar to the counterpart in the [JSON API](https://internetcomputer.org/docs/current/developer-docs/http-compatible-canisters/serving-json-over-http) example with the biggest difference being in the headers that are used. Since the responses from an API serving static assets will be rendered directly in the browser, more security-focused headers are necessary:
 
 ```rust
-fn create_asset_response(
+fn get_asset_headers(
     additional_headers: Vec<HeaderField>,
     body: &[u8],
     cel_expr: String,
-) -> HttpResponse {
+) -> Vec<(String, String)> {
     // set up the default headers and include additional headers provided by the caller
     let mut headers = vec![
         ("strict-transport-security".to_string(), "max-age=31536000; includeSubDomains".to_string()),
@@ -160,6 +161,16 @@ fn create_asset_response(
         (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
     ];
     headers.extend(additional_headers);
+
+    headers
+}
+
+fn create_asset_response(
+    additional_headers: Vec<HeaderField>,
+    body: &[u8],
+    cel_expr: String,
+) -> HttpResponse {
+    let headers = get_asset_headers(additional_headers, body, cel_expr);
 
     HttpResponse::builder()
         .with_status_code(200)
@@ -195,9 +206,6 @@ fn certify_asset_response(
                 asset_tree_path,
                 &certification,
             ));
-
-            // set the canister's certified data
-            set_certified_data(&http_tree.root_hash());
         });
 
         RESPONSES.with_borrow_mut(|responses| {
@@ -253,9 +261,6 @@ fn certify_asset_with_encoding(
                     asset_tree_path,
                     &certification,
                 ));
-
-                // set the canister's certified data
-                set_certified_data(&http_tree.root_hash());
             });
 
             ENCODED_RESPONSES.with_borrow_mut(|responses| {
@@ -381,15 +386,47 @@ fn certify_index_asset() {
 }
 ```
 
+It's also possible to skip certification for certain routes. This can be relatively easily as follows:
+
+```rust
+const DYNAMIC_REQ_PATH: &str = "/dynamic";
+
+fn certify_dynamic_asset() {
+    let dynamic_req_tree_path = HttpCertificationPath::exact(DYNAMIC_REQ_PATH);
+    let dynamic_req_certification = HttpCertification::skip();
+
+    HTTP_TREE.with_borrow_mut(|http_tree| {
+        http_tree.insert(&HttpCertificationTreeEntry::new(
+            dynamic_req_tree_path,
+            &dynamic_req_certification,
+        ));
+    });
+}
+```
+
+After setting all certifications, the canister's [certified data](https://internetcomputer.org/docs/current/references/ic-interface-spec#system-api-certified-data) needs to be set. This will make sure that the correct certified data is set so that it can be signed during the next consensus round:
+
+```rust
+fn update_certified_data() {
+    HTTP_TREE.with_borrow(|http_tree| {
+        set_certified_data(&http_tree.root_hash());
+    });
+}
+```
+
 With all of the above functions, it is now possible to certify all of the frontend project's assets simply.
 
 ```rust
 fn certify_all_assets() {
+    certify_dynamic_asset();
+
     certify_index_asset();
     certify_asset_glob("assets/**/*.css", "text/css");
     certify_asset_glob("assets/**/*.js", "text/javascript");
     certify_asset_glob("assets/**/*.ico", "image/x-icon");
     certify_asset_glob("assets/**/*.svg", "image/svg+xml");
+
+    update_certified_data();
 }
 ```
 
@@ -397,6 +434,8 @@ fn certify_all_assets() {
 
 With all assets certified, they can be served over HTTP. The steps to follow when serving assets are:
 
+- Check if the request path matches the dynamic path.
+  - If the requested path exactly matches the dynamic path, serve the dynamic response.
 - Check if the requested path matches a file (e.g., `/assets/app.js`).
   - If the request path exactly matches an existing file, serve that file.
   - Otherwise, serve the `index.html` file.
@@ -413,19 +452,30 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     RESPONSES.with_borrow(|responses| {
         ENCODED_RESPONSES.with_borrow(|encoded_responses| {
             let (asset_req_path, asset_tree_path, identity_response) =
+            // if the request path matches the dynamic response's path, serve that
+            if req_path == DYNAMIC_REQ_PATH {
+                (
+                    DYNAMIC_REQ_PATH.to_string(),
+                    HttpCertificationPath::exact(DYNAMIC_REQ_PATH),
+                    CertifiedHttpResponse {
+                        response: create_dynamic_response(),
+                        certification: HttpCertification::skip(),
+                    },
+                )
+            }
             // if the requested path matches a static asset, serve that
-            if let Some(identity_response) = responses.get(&req_path) {
+            else if let Some(identity_response) = responses.get(&req_path) {
                 (
                     req_path.to_string(),
                     HttpCertificationPath::exact(&req_path),
-                    identity_response,
+                    identity_response.clone(),
                 )
             // otherwise serve the index.html
             } else {
                 (
                     INDEX_REQ_PATH.to_string(),
                     INDEX_TREE_PATH.to_owned(),
-                    responses.get(*INDEX_REQ_PATH).unwrap(),
+                    responses.get(*INDEX_REQ_PATH).unwrap().clone(),
                 )
             };
 
@@ -448,7 +498,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
                         if let Some(br_response) =
                             encoded_responses.get(&(asset_req_path.clone(), "br".to_string()))
                         {
-                            return Some(br_response);
+                            return Some(br_response.clone());
                         }
                     }
 
@@ -457,7 +507,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
                         if let Some(gzip_response) =
                             encoded_responses.get(&(asset_req_path, "gzip".to_string()))
                         {
-                            return Some(gzip_response);
+                            return Some(gzip_response.clone());
                         }
                     }
 
@@ -487,6 +537,46 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     })
 }
 ```
+
+Creating the dynamic response is done as follows:
+
+```rust
+fn create_dynamic_response() -> HttpResponse<'static> {
+    let body = format!(
+        r#"
+            <html>
+                <head>
+                    <title>ICP Skip Certification</title>
+                </head>
+
+                <body>
+                    <h1>ICP Skip Certification</h1>
+                    <p>This is an example of an IC canister that skips certification.</p>
+                    <p>Current timestamp: {}<b>
+                </body>
+            </html>
+        "#,
+        time()
+    )
+    .as_bytes()
+    .to_vec();
+    let additional_headers = vec![("content-type".to_string(), "text/html".to_string())];
+
+    let headers = get_asset_headers(
+        additional_headers,
+        &body,
+        DefaultCelBuilder::skip_certification().to_string(),
+    );
+
+    HttpResponse::builder()
+        .with_status_code(200)
+        .with_headers(headers)
+        .with_body(body)
+        .build()
+}
+```
+
+Recall that verification is skipped for this asset, so the response will not be validated and it's possible for the canister (or the replica) to return virtually anything, malicious or otherwise.
 
 This function can then be simply linked up to the `http_request` handler:
 

--- a/examples/http-certification/custom-assets/dfx.json
+++ b/examples/http-certification/custom-assets/dfx.json
@@ -12,7 +12,11 @@
       "build": [
         "pnpm -F http-certification-custom-assets-frontend build",
         "cargo build --target wasm32-unknown-unknown --release -p http_certification_custom_assets_backend --locked"
-      ]
+      ],
+      "declarations": {
+        "bindings": ["ts", "js"],
+        "output": "src/declarations"
+      }
     }
   }
 }

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk::{
-    api::{data_certificate, set_certified_data},
+    api::{data_certificate, set_certified_data, time},
     *,
 };
 use ic_http_certification::{
@@ -31,6 +31,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 }
 
 // Storage
+#[derive(Clone)]
 struct CertifiedHttpResponse<'a> {
     response: HttpResponse<'a>,
     certification: HttpCertification,
@@ -73,11 +74,29 @@ fn prepare_cel_exprs() {
 }
 
 fn certify_all_assets() {
+    certify_dynamic_asset();
+
     certify_index_asset();
     certify_asset_glob("assets/**/*.css", "text/css");
     certify_asset_glob("assets/**/*.js", "text/javascript");
     certify_asset_glob("assets/**/*.ico", "image/x-icon");
     certify_asset_glob("assets/**/*.svg", "image/svg+xml");
+
+    update_certified_data();
+}
+
+const DYNAMIC_REQ_PATH: &str = "/dynamic";
+
+fn certify_dynamic_asset() {
+    let dynamic_req_tree_path = HttpCertificationPath::exact(DYNAMIC_REQ_PATH);
+    let dynamic_req_certification = HttpCertification::skip();
+
+    HTTP_TREE.with_borrow_mut(|http_tree| {
+        http_tree.insert(&HttpCertificationTreeEntry::new(
+            dynamic_req_tree_path,
+            &dynamic_req_certification,
+        ));
+    });
 }
 
 fn certify_index_asset() {
@@ -200,9 +219,6 @@ fn certify_asset_with_encoding(
                     asset_tree_path,
                     &certification,
                 ));
-
-                // set the canister's certified data
-                set_certified_data(&http_tree.root_hash());
             });
 
             ENCODED_RESPONSES.with_borrow_mut(|responses| {
@@ -242,9 +258,6 @@ fn certify_asset_response(
                 asset_tree_path,
                 &certification,
             ));
-
-            // set the canister's certified data
-            set_certified_data(&http_tree.root_hash());
         });
 
         RESPONSES.with_borrow_mut(|responses| {
@@ -260,6 +273,12 @@ fn certify_asset_response(
     });
 }
 
+fn update_certified_data() {
+    HTTP_TREE.with_borrow(|http_tree| {
+        set_certified_data(&http_tree.root_hash());
+    });
+}
+
 // Handlers
 fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     let req_path = req.get_path().expect("Failed to get req path");
@@ -267,19 +286,30 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     RESPONSES.with_borrow(|responses| {
         ENCODED_RESPONSES.with_borrow(|encoded_responses| {
             let (asset_req_path, asset_tree_path, identity_response) =
+            // if the request path matches the dynamic response's path, serve that
+            if req_path == DYNAMIC_REQ_PATH {
+                (
+                    DYNAMIC_REQ_PATH.to_string(),
+                    HttpCertificationPath::exact(DYNAMIC_REQ_PATH),
+                    CertifiedHttpResponse {
+                        response: create_dynamic_response(),
+                        certification: HttpCertification::skip(),
+                    },
+                )
+            }
             // if the requested path matches a static asset, serve that
-            if let Some(identity_response) = responses.get(&req_path) {
+            else if let Some(identity_response) = responses.get(&req_path) {
                 (
                     req_path.to_string(),
                     HttpCertificationPath::exact(&req_path),
-                    identity_response,
+                    identity_response.clone(),
                 )
             // otherwise serve the index.html
             } else {
                 (
                     INDEX_REQ_PATH.to_string(),
                     INDEX_TREE_PATH.to_owned(),
-                    responses.get(*INDEX_REQ_PATH).unwrap(),
+                    responses.get(*INDEX_REQ_PATH).unwrap().clone(),
                 )
             };
 
@@ -302,7 +332,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
                         if let Some(br_response) =
                             encoded_responses.get(&(asset_req_path.clone(), "br".to_string()))
                         {
-                            return Some(br_response);
+                            return Some(br_response.clone());
                         }
                     }
 
@@ -311,7 +341,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
                         if let Some(gzip_response) =
                             encoded_responses.get(&(asset_req_path, "gzip".to_string()))
                         {
-                            return Some(gzip_response);
+                            return Some(gzip_response.clone());
                         }
                     }
 
@@ -341,11 +371,45 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     })
 }
 
-fn create_asset_response(
+fn create_dynamic_response() -> HttpResponse<'static> {
+    let body = format!(
+        r#"
+            <html>
+                <head>
+                    <title>ICP Skip Certification</title>
+                </head>
+
+                <body>
+                    <h1>ICP Skip Certification</h1>
+                    <p>This is an example of an IC canister that skips certification.</p>
+                    <p>Current timestamp: {}<b>
+                </body>
+            </html>
+        "#,
+        time()
+    )
+    .as_bytes()
+    .to_vec();
+    let additional_headers = vec![("content-type".to_string(), "text/html".to_string())];
+
+    let headers = get_asset_headers(
+        additional_headers,
+        &body,
+        DefaultCelBuilder::skip_certification().to_string(),
+    );
+
+    HttpResponse::builder()
+        .with_status_code(200)
+        .with_headers(headers)
+        .with_body(body)
+        .build()
+}
+
+fn get_asset_headers(
     additional_headers: Vec<HeaderField>,
     body: &[u8],
     cel_expr: String,
-) -> HttpResponse {
+) -> Vec<(String, String)> {
     // set up the default headers and include additional headers provided by the caller
     let mut headers = vec![
         ("strict-transport-security".to_string(), "max-age=31536000; includeSubDomains".to_string()),
@@ -360,6 +424,16 @@ fn create_asset_response(
         (CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(), cel_expr),
     ];
     headers.extend(additional_headers);
+
+    headers
+}
+
+fn create_asset_response(
+    additional_headers: Vec<HeaderField>,
+    body: &[u8],
+    cel_expr: String,
+) -> HttpResponse {
+    let headers = get_asset_headers(additional_headers, body, cel_expr);
 
     HttpResponse::builder()
         .with_status_code(200)

--- a/examples/http-certification/custom-assets/src/tests/jest.config.ts
+++ b/examples/http-certification/custom-assets/src/tests/jest.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  watch: false,
+  preset: 'ts-jest/presets/js-with-ts',
+  testEnvironment: 'node',
+  verbose: true,
+};
+
+export default config;

--- a/examples/http-certification/custom-assets/src/tests/package.json
+++ b/examples/http-certification/custom-assets/src/tests/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "http-certification-custom-assets-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@dfinity/response-verification": "workspace:*"
+  }
+}

--- a/examples/http-certification/custom-assets/src/tests/src/http.spec.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/http.spec.ts
@@ -1,0 +1,68 @@
+import { Actor, PocketIc } from '@hadronous/pic';
+import { Principal } from '@dfinity/principal';
+import {
+  verifyRequestResponsePair,
+  Request,
+} from '@dfinity/response-verification';
+
+import { _SERVICE } from '../../declarations/backend.did';
+import { setupBackendCanister } from './wasm';
+import { CERTIFICATE_VERSION, mapToCanisterRequest } from './request';
+import { mapFromCanisterResponse } from './response';
+
+const NS_PER_MS = 1e6;
+const MS_PER_S = 1e3;
+const S_PER_MIN = 60;
+
+describe('HTTP', () => {
+  let pic: PocketIc;
+  let actor: Actor<_SERVICE>;
+  let canisterId: Principal;
+
+  let rootKey: ArrayBufferLike;
+
+  const currentDate = new Date(2021, 6, 10, 0, 0, 0, 0);
+  const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
+  const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
+
+  beforeEach(async () => {
+    pic = await PocketIc.create();
+    const fixture = await setupBackendCanister(pic, currentDate);
+    actor = fixture.actor;
+    canisterId = fixture.canisterId;
+
+    const subnets = pic.getApplicationSubnets();
+    rootKey = await pic.getPubKey(subnets[0].id);
+  });
+
+  afterEach(async () => {
+    await pic.tearDown();
+  });
+
+  it('should successfully skip verification', async () => {
+    const request: Request = {
+      url: '/dynamic',
+      method: 'GET',
+      headers: [],
+      body: new Uint8Array(),
+    };
+    const canisterRequest = mapToCanisterRequest(request);
+
+    const canisterResponse = await actor.http_request(canisterRequest);
+    const response = mapFromCanisterResponse(canisterResponse);
+    expect(response.statusCode).toBe(200);
+
+    let verificationResult = verifyRequestResponsePair(
+      request,
+      response,
+      canisterId.toUint8Array(),
+      currentTimeNs,
+      maxCertTimeOffsetNs,
+      new Uint8Array(rootKey),
+      CERTIFICATE_VERSION,
+    );
+
+    expect(verificationResult.verificationVersion).toEqual(CERTIFICATE_VERSION);
+    expect(verificationResult.response).toBeUndefined();
+  });
+});

--- a/examples/http-certification/custom-assets/src/tests/src/http.spec.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/http.spec.ts
@@ -41,7 +41,7 @@ describe('HTTP', () => {
 
   it('should successfully skip verification', async () => {
     const request: Request = {
-      url: '/dynamic',
+      url: '/uncertified',
       method: 'GET',
       headers: [],
       body: new Uint8Array(),

--- a/examples/http-certification/custom-assets/src/tests/src/request.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/request.ts
@@ -1,0 +1,14 @@
+import { Request } from '@dfinity/response-verification';
+import { HttpRequest } from '../../declarations/backend.did';
+
+export const CERTIFICATE_VERSION = 2;
+
+export function mapToCanisterRequest(request: Request): HttpRequest {
+  return {
+    url: request.url,
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    certificate_version: [CERTIFICATE_VERSION],
+  };
+}

--- a/examples/http-certification/custom-assets/src/tests/src/response.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/response.ts
@@ -1,0 +1,10 @@
+import { Response } from '@dfinity/response-verification';
+import { HttpResponse } from '../../declarations/backend.did';
+
+export function mapFromCanisterResponse(response: HttpResponse): Response {
+  return {
+    statusCode: response.status_code,
+    headers: response.headers,
+    body: Uint8Array.from(response.body),
+  };
+}

--- a/examples/http-certification/custom-assets/src/tests/src/wasm.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/wasm.ts
@@ -1,0 +1,29 @@
+import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { resolve } from 'node:path';
+import { type _SERVICE, idlFactory } from '../../declarations/backend.did';
+
+export const BACKEND_WASM_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'target',
+  'wasm32-unknown-unknown',
+  'release',
+  'http_certification_skip_certification_backend.wasm',
+);
+
+export async function setupBackendCanister(
+  pic: PocketIc,
+  initialDate: Date,
+): Promise<CanisterFixture<_SERVICE>> {
+  await pic.setTime(initialDate.getTime());
+
+  return await pic.setupCanister<_SERVICE>({
+    idlFactory,
+    wasm: BACKEND_WASM_PATH,
+  });
+}

--- a/examples/http-certification/custom-assets/src/tests/tsconfig.json
+++ b/examples/http-certification/custom-assets/src/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/examples/http-certification/skip-certification/.gitignore
+++ b/examples/http-certification/skip-certification/.gitignore
@@ -1,0 +1,21 @@
+# Various IDEs and Editors
+.vscode/
+.idea/
+**/*~
+
+# Mac OSX temporary files
+.DS_Store
+**/.DS_Store
+
+# dfx temporary files
+.dfx/
+
+# generated files
+src/declarations/
+
+# rust
+target/
+
+# frontend code
+node_modules/
+dist/

--- a/examples/http-certification/skip-certification/README.md
+++ b/examples/http-certification/skip-certification/README.md
@@ -1,0 +1,96 @@
+# Skipping certification for HTTP responses
+
+## Overview
+
+This guide walks through an example project that demonstrates how to skip HTTP certification for all possible responses from a canister.
+
+WARNING!!! This means that a malicious replica can return whatever data it wants in response to requests directed towards the canister. Think carefully about whether or not this is the right fit for the canister. If certification should only be skipped for certain paths, then check out the ["Serving static assets over HTTP"](https://internetcomputer.org/docs/current/developer-docs/web-apps/http-compatible-canisters/serving-static-assets-over-http) guide where this approach is covered in more detail.
+
+This is not a beginner's canister development guide. Many foundational concepts that a relatively experienced canister developer should already know will be omitted. Concepts specific to HTTP Certification will be called out here and can help to understand the [full code example](https://github.com/dfinity/response-verification/tree/main/examples/http-certification/skip-certification).
+
+## Prerequisites
+
+This is a relatively simple guide so there's no prerequisites as such, but it's recommended to check out the full certification guides to make sure that certification is not a good fit for your project.
+
+- [x] Complete the ["Serving static assets over HTTP"](https://internetcomputer.org/docs/current/developer-docs/web-apps/http-compatible-canisters/serving-static-assets-over-http) guide.
+- [x] Complete the ["Custom HTTP Canisters"](https://internetcomputer.org/docs/current/developer-docs/http-compatible-canisters/custom-http-canisters) guide.
+- [x] Complete the ["Serving JSON over HTTP"](https://internetcomputer.org/docs/current/developer-docs/http-compatible-canisters/serving-json-over-http) guide.
+
+# Skipping certification
+
+Skipping certification for all responses is a relatively simple task that can be completed in 2 very simple steps.
+
+First, set the canister's certified data in the canister's `init` lifecycle hook:
+
+```rust
+#[init]
+fn init() {
+    set_certified_data(&skip_certification_certified_data());
+}
+```
+
+This will make sure that the correct certified data is set so that it can be signed during the next consensus round.
+
+Next, when responding to HTTP requests, add the certificate header that will instruct the HTTP Gateway to skip verification:
+
+```rust
+#[query]
+fn http_request() -> HttpResponse<'static> {
+    let mut response = create_response();
+
+    add_skip_certification_header(data_certificate().unwrap(), &mut response);
+
+    response
+}
+```
+
+The call to `data_certificate` returns a certificate that proves the canister's certified data was signed by consensus. This will be included in the header along with all additional information required by the HTTP Gateway to safely skip verification of this response.
+
+# Testing out the canister
+
+Start DFX:
+
+```shell
+dfx start --background
+```
+
+Deploy the canister:
+
+```shell
+dfx deploy
+```
+
+Make a request to the canister using cURL:
+
+```shell
+curl http://localhost:$(dfx info webserver-port)?canisterId=$(dfx canister id backend)
+```
+
+You should see output similar to the following:
+
+```html
+<html>
+  <head>
+    <title>IC Skip Certification</title>
+  </head>
+
+  <body>
+    <h1>IC Skip Certification</h1>
+    <p>This is an example of an IC canister that skips certification.</p>
+    <p>Current timestamp: 1725546616552162368<b>
+  </body>
+</html>
+```
+
+Alternatively, print the URL in the terminal and then open in a browser:
+
+```shell
+echo http://localhost:$(dfx info webserver-port)?canisterId=$(dfx canister id backend)
+```
+
+## Resources
+
+- [Example source code](https://github.com/dfinity/response-verification/tree/main/examples/http-certification/skip-certification).
+- [`ic-http-certification` crate](https://crates.io/crates/ic-http-certification).
+- [`ic-http-certification` docs](https://docs.rs/ic-http-certification/latest/ic_http_certification).
+- [`ic-http-certification` source code](https://github.com/dfinity/response-verification/tree/main/packages/ic-http-certification).

--- a/examples/http-certification/skip-certification/README.md
+++ b/examples/http-certification/skip-certification/README.md
@@ -18,11 +18,14 @@ This is a relatively simple guide so there's no prerequisites as such, but it's 
 
 # Skipping certification
 
-Skipping certification for all responses is a relatively simple task that can be completed in 2 very simple steps.
+Skipping certification for all responses is a relatively simple task that can be completed in 2 steps.
 
 First, set the canister's certified data in the canister's `init` lifecycle hook:
 
 ```rust
+use ic_cdk::*;
+use ic_http_certification::utils::skip_certification_certified_data;
+
 #[init]
 fn init() {
     set_certified_data(&skip_certification_certified_data());
@@ -34,6 +37,9 @@ This will make sure that the correct certified data is set so that it can be sig
 Next, when responding to HTTP requests, add the certificate header that will instruct the HTTP Gateway to skip verification:
 
 ```rust
+use ic_cdk::{api::data_certificate, *};
+use ic_http_certification::utils::add_skip_certification_header;
+
 #[query]
 fn http_request() -> HttpResponse<'static> {
     let mut response = create_response();

--- a/examples/http-certification/skip-certification/dfx.json
+++ b/examples/http-certification/skip-certification/dfx.json
@@ -1,0 +1,16 @@
+{
+  "dfx": "0.18.0",
+  "version": 1,
+  "output_env_file": ".env",
+  "canisters": {
+    "backend": {
+      "candid": "src/backend/backend.did",
+      "package": "http_certification_skip_certification_backend",
+      "type": "rust",
+      "declarations": {
+        "bindings": ["ts", "js"],
+        "output": "src/declarations"
+      }
+    }
+  }
+}

--- a/examples/http-certification/skip-certification/src/backend/Cargo.toml
+++ b/examples/http-certification/skip-certification/src/backend/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "http_certification_skip_certification_backend"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid.workspace = true
+ic-cdk.workspace = true
+ic-http-certification.workspace = true

--- a/examples/http-certification/skip-certification/src/backend/backend.did
+++ b/examples/http-certification/skip-certification/src/backend/backend.did
@@ -1,0 +1,19 @@
+type HeaderField = record { text; text };
+
+type HttpRequest = record {
+  method : text;
+  url : text;
+  headers : vec HeaderField;
+  body : blob;
+  certificate_version : opt nat16;
+};
+
+type HttpResponse = record {
+  status_code : nat16;
+  headers : vec HeaderField;
+  body : blob;
+};
+
+service : {
+  http_request : (request : HttpRequest) -> (HttpResponse) query;
+};

--- a/examples/http-certification/skip-certification/src/backend/src/lib.rs
+++ b/examples/http-certification/skip-certification/src/backend/src/lib.rs
@@ -1,0 +1,62 @@
+use ic_cdk::{
+    api::{data_certificate, set_certified_data, time},
+    *,
+};
+use ic_http_certification::{
+    utils::{add_skip_certification_header, skip_certification_certified_data},
+    HttpResponse,
+};
+
+#[init]
+fn init() {
+    set_certified_data(&skip_certification_certified_data());
+}
+
+#[query]
+fn http_request() -> HttpResponse<'static> {
+    let mut response = create_response();
+
+    add_skip_certification_header(data_certificate().unwrap(), &mut response);
+
+    response
+}
+
+fn create_response() -> HttpResponse<'static> {
+    let body = format!(
+        r#"
+            <html>
+                <head>
+                    <title>ICP Skip Certification</title>
+                </head>
+
+                <body>
+                    <h1>ICP Skip Certification</h1>
+                    <p>This is an example of an IC canister that skips certification.</p>
+                    <p>Current timestamp: {}<b>
+                </body>
+            </html>
+        "#,
+        time()
+    )
+    .as_bytes()
+    .to_vec();
+
+    let headers = vec![
+        ("strict-transport-security".to_string(), "max-age=31536000; includeSubDomains".to_string()),
+        ("x-frame-options".to_string(), "DENY".to_string()),
+        ("x-content-type-options".to_string(), "nosniff".to_string()),
+        ("content-security-policy".to_string(), "default-src 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content".to_string()),
+        ("referrer-policy".to_string(), "no-referrer".to_string()),
+        ("permissions-policy".to_string(), "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()".to_string()),
+        ("cross-origin-embedder-policy".to_string(), "require-corp".to_string()),
+        ("cross-origin-opener-policy".to_string(), "same-origin".to_string()),
+        ("content-length".to_string(), body.len().to_string()),
+        ("content-type".to_string(), "text/html".to_string())
+    ];
+
+    HttpResponse::builder()
+        .with_status_code(200)
+        .with_headers(headers)
+        .with_body(body)
+        .build()
+}

--- a/examples/http-certification/skip-certification/src/tests/jest.config.ts
+++ b/examples/http-certification/skip-certification/src/tests/jest.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  watch: false,
+  preset: 'ts-jest/presets/js-with-ts',
+  testEnvironment: 'node',
+  verbose: true,
+};
+
+export default config;

--- a/examples/http-certification/skip-certification/src/tests/package.json
+++ b/examples/http-certification/skip-certification/src/tests/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "http-certification-skip-certification-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@dfinity/response-verification": "workspace:*"
+  }
+}

--- a/examples/http-certification/skip-certification/src/tests/src/http.spec.ts
+++ b/examples/http-certification/skip-certification/src/tests/src/http.spec.ts
@@ -1,0 +1,68 @@
+import { Actor, PocketIc } from '@hadronous/pic';
+import { Principal } from '@dfinity/principal';
+import {
+  verifyRequestResponsePair,
+  Request,
+} from '@dfinity/response-verification';
+
+import { _SERVICE } from '../../declarations/backend.did';
+import { setupBackendCanister } from './wasm';
+import { CERTIFICATE_VERSION, mapToCanisterRequest } from './request';
+import { mapFromCanisterResponse } from './response';
+
+const NS_PER_MS = 1e6;
+const MS_PER_S = 1e3;
+const S_PER_MIN = 60;
+
+describe('HTTP', () => {
+  let pic: PocketIc;
+  let actor: Actor<_SERVICE>;
+  let canisterId: Principal;
+
+  let rootKey: ArrayBufferLike;
+
+  const currentDate = new Date(2021, 6, 10, 0, 0, 0, 0);
+  const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
+  const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
+
+  beforeEach(async () => {
+    pic = await PocketIc.create();
+    const fixture = await setupBackendCanister(pic, currentDate);
+    actor = fixture.actor;
+    canisterId = fixture.canisterId;
+
+    const subnets = pic.getApplicationSubnets();
+    rootKey = await pic.getPubKey(subnets[0].id);
+  });
+
+  afterEach(async () => {
+    await pic.tearDown();
+  });
+
+  it('should successfully skip verification', async () => {
+    const request: Request = {
+      url: '/',
+      method: 'GET',
+      headers: [],
+      body: new Uint8Array(),
+    };
+    const canisterRequest = mapToCanisterRequest(request);
+
+    const canisterResponse = await actor.http_request(canisterRequest);
+    const response = mapFromCanisterResponse(canisterResponse);
+    expect(response.statusCode).toBe(200);
+
+    let verificationResult = verifyRequestResponsePair(
+      request,
+      response,
+      canisterId.toUint8Array(),
+      currentTimeNs,
+      maxCertTimeOffsetNs,
+      new Uint8Array(rootKey),
+      CERTIFICATE_VERSION,
+    );
+
+    expect(verificationResult.verificationVersion).toEqual(CERTIFICATE_VERSION);
+    expect(verificationResult.response).toBeUndefined();
+  });
+});

--- a/examples/http-certification/skip-certification/src/tests/src/request.ts
+++ b/examples/http-certification/skip-certification/src/tests/src/request.ts
@@ -1,0 +1,14 @@
+import { Request } from '@dfinity/response-verification';
+import { HttpRequest } from '../../declarations/backend.did';
+
+export const CERTIFICATE_VERSION = 2;
+
+export function mapToCanisterRequest(request: Request): HttpRequest {
+  return {
+    url: request.url,
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    certificate_version: [CERTIFICATE_VERSION],
+  };
+}

--- a/examples/http-certification/skip-certification/src/tests/src/response.ts
+++ b/examples/http-certification/skip-certification/src/tests/src/response.ts
@@ -1,0 +1,10 @@
+import { Response } from '@dfinity/response-verification';
+import { HttpResponse } from '../../declarations/backend.did';
+
+export function mapFromCanisterResponse(response: HttpResponse): Response {
+  return {
+    statusCode: response.status_code,
+    headers: response.headers,
+    body: Uint8Array.from(response.body),
+  };
+}

--- a/examples/http-certification/skip-certification/src/tests/src/wasm.ts
+++ b/examples/http-certification/skip-certification/src/tests/src/wasm.ts
@@ -1,0 +1,29 @@
+import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { resolve } from 'node:path';
+import { type _SERVICE, idlFactory } from '../../declarations/backend.did';
+
+export const BACKEND_WASM_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'target',
+  'wasm32-unknown-unknown',
+  'release',
+  'http_certification_skip_certification_backend.wasm',
+);
+
+export async function setupBackendCanister(
+  pic: PocketIc,
+  initialDate: Date,
+): Promise<CanisterFixture<_SERVICE>> {
+  await pic.setTime(initialDate.getTime());
+
+  return await pic.setupCanister<_SERVICE>({
+    idlFactory,
+    wasm: BACKEND_WASM_PATH,
+  });
+}

--- a/examples/http-certification/skip-certification/src/tests/tsconfig.json
+++ b/examples/http-certification/skip-certification/src/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/ic-asset-certification/README.md
+++ b/packages/ic-asset-certification/README.md
@@ -653,7 +653,7 @@ asset_router
     .unwrap();
 ```
 
-To delete the `app.js`asset, along with the alternative encodings:
+To delete the `app.js` asset, along with the alternative encodings:
 
 ```rust
 # use ic_asset_certification::{Asset, AssetConfig, AssetFallbackConfig, AssetRouter, AssetRedirectKind, AssetEncoding};

--- a/packages/ic-http-certification/src/utils/mod.rs
+++ b/packages/ic-http-certification/src/utils/mod.rs
@@ -2,8 +2,11 @@
 //! They are exported for use in other libraries that depend on this one, or for
 //! advanced use cases that require custom logic.
 
+mod response_header;
+pub use response_header::*;
+
 mod wildcard_paths;
 pub use wildcard_paths::*;
 
-mod response_header;
-pub use response_header::*;
+mod skip_certification;
+pub use skip_certification::*;

--- a/packages/ic-http-certification/src/utils/response_header.rs
+++ b/packages/ic-http-certification/src/utils/response_header.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 ///     [`HttpCertificationPath::to_expr_path()`](crate::HttpCertificationPath::to_expr_path). The expression path
 ///     is not validated to be correct for the given response, and the function will not fail if the expression path is invalid.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use ic_http_certification::{HttpCertification, HttpRequest, HttpResponse, DefaultCelBuilder, DefaultResponseCertification, HttpCertificationTree, HttpCertificationTreeEntry, HttpCertificationPath, CERTIFICATE_EXPRESSION_HEADER_NAME, CERTIFICATE_HEADER_NAME, utils::add_v2_certificate_header};

--- a/packages/ic-http-certification/src/utils/skip_certification.rs
+++ b/packages/ic-http-certification/src/utils/skip_certification.rs
@@ -1,0 +1,88 @@
+use super::add_certificate_header;
+use crate::{
+    DefaultCelBuilder, Hash, HttpCertificationPath, HttpResponse,
+    CERTIFICATE_EXPRESSION_HEADER_NAME,
+};
+use ic_certification::{hash_tree::leaf, labeled, HashTree};
+use ic_representation_independent_hash::hash;
+
+/// Adds the `IC-Certificate` and `IC-Certificate-Expression` headers to a given [`HttpResponse`]. These headers are used by the HTTP Gateway
+/// to verify the authenticity of query call responses. In this case, the headers are pre-configured to instruct
+/// the HTTP Gateway to skip certification verification in a secure way. Secure in this context means that
+/// the decision to skip certification is made by the canister itself, and not by the replica, API boundary nodes
+/// or any other intermediate party.
+///
+/// # Arguments
+///
+/// * `data_certificate` - A certificate used by the HTTP Gateway to verify a response.
+///    Retrieved using `ic_cdk::api::data_certificate`.
+/// * `response` - The [`HttpResponse`] to add the certificate header to.
+///   Created using [`HttpResponse::builder()`](crate::HttpResponse::builder).
+///
+/// # Examples
+///
+/// ```
+/// use ic_http_certification::{HttpResponse, DefaultCelBuilder, utils::add_skip_certification_header, CERTIFICATE_EXPRESSION_HEADER_NAME, CERTIFICATE_HEADER_NAME};
+///
+/// let mut response = HttpResponse::builder().build();
+///
+/// let data_certificate = vec![1, 2, 3];
+///
+/// add_skip_certification_header(data_certificate, &mut response);
+///
+/// assert_eq!(
+///     response.headers(),
+///     vec![
+///         (
+///             CERTIFICATE_HEADER_NAME.to_string(),
+///             "certificate=:AQID:, tree=:2dn3gwJJaHR0cF9leHBygwJDPCo+gwJYIMMautvQsFn51GT9bfTani3Ah659C0BGjTNyJtQTszcjggNA:, expr_path=:2dn3gmlodHRwX2V4cHJjPCo+:, version=2".to_string(),
+///         ),
+///         (
+///             CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+///             DefaultCelBuilder::skip_certification().to_string()
+///         ),
+///     ]
+/// );
+/// ```
+pub fn add_skip_certification_header(data_certificate: Vec<u8>, response: &mut HttpResponse) {
+    add_certificate_header(
+        data_certificate,
+        response,
+        &skip_certification_asset_tree(),
+        &HttpCertificationPath::wildcard("").to_expr_path(),
+    );
+
+    response.add_header((
+        CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+        DefaultCelBuilder::skip_certification().to_string(),
+    ));
+}
+
+/// Returns the hash of the certified data that can be used to instruct HTTP Gateways to skip certification.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ic_http_certification::utils::skip_certification_certified_data;
+/// use ic_cdk::api::set_certified_data;
+///
+/// let certified_data = skip_certification_certified_data();
+///
+/// set_certified_date(&certified_data);
+/// ```
+pub fn skip_certification_certified_data() -> Hash {
+    skip_certification_asset_tree().digest()
+}
+
+fn skip_certification_asset_tree() -> HashTree {
+    let cel_expr_hash = hash(
+        DefaultCelBuilder::skip_certification()
+            .to_string()
+            .as_bytes(),
+    );
+
+    labeled(
+        "http_expr",
+        labeled("<*>", labeled(cel_expr_hash, leaf(vec![]))),
+    )
+}

--- a/packages/ic-http-certification/src/utils/skip_certification.rs
+++ b/packages/ic-http-certification/src/utils/skip_certification.rs
@@ -1,4 +1,4 @@
-use super::add_certificate_header;
+use super::add_v2_certificate_header;
 use crate::{
     DefaultCelBuilder, Hash, HttpCertificationPath, HttpResponse,
     CERTIFICATE_EXPRESSION_HEADER_NAME,
@@ -26,6 +26,7 @@ use ic_representation_independent_hash::hash;
 ///
 /// let mut response = HttpResponse::builder().build();
 ///
+/// // this should normally be retrieved using `ic_cdk::api::data_certificate()`.
 /// let data_certificate = vec![1, 2, 3];
 ///
 /// add_skip_certification_header(data_certificate, &mut response);
@@ -45,8 +46,8 @@ use ic_representation_independent_hash::hash;
 /// );
 /// ```
 pub fn add_skip_certification_header(data_certificate: Vec<u8>, response: &mut HttpResponse) {
-    add_certificate_header(
-        data_certificate,
+    add_v2_certificate_header(
+        &data_certificate,
         response,
         &skip_certification_asset_tree(),
         &HttpCertificationPath::wildcard("").to_expr_path(),
@@ -68,7 +69,7 @@ pub fn add_skip_certification_header(data_certificate: Vec<u8>, response: &mut H
 ///
 /// let certified_data = skip_certification_certified_data();
 ///
-/// set_certified_date(&certified_data);
+/// set_certified_data(&certified_data);
 /// ```
 pub fn skip_certification_certified_data() -> Hash {
     skip_certification_asset_tree().digest()
@@ -85,4 +86,22 @@ fn skip_certification_asset_tree() -> HashTree {
         "http_expr",
         labeled("<*>", labeled(cel_expr_hash, leaf(vec![]))),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skip_certification_certified_data() {
+        let certified_data = skip_certification_certified_data();
+
+        assert_eq!(
+            certified_data,
+            [
+                85, 236, 195, 28, 62, 128, 71, 252, 21, 143, 32, 234, 10, 160, 96, 154, 172, 199,
+                181, 126, 6, 234, 64, 220, 65, 134, 2, 114, 167, 214, 66, 145
+            ]
+        );
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,19 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0(solid-js@1.7.6)(vite@4.5.2(@types/node@20.11.30)(terser@5.18.1))
 
+  examples/http-certification/custom-assets/src/tests:
+    devDependencies:
+      '@dfinity/response-verification':
+        specifier: workspace:*
+        version: link:../../../../../packages/ic-response-verification-wasm
+
   examples/http-certification/json-api/src/tests:
+    devDependencies:
+      '@dfinity/response-verification':
+        specifier: workspace:*
+        version: link:../../../../../packages/ic-response-verification-wasm
+
+  examples/http-certification/skip-certification/src/tests:
     devDependencies:
       '@dfinity/response-verification':
         specifier: workspace:*
@@ -1795,6 +1807,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -1936,6 +1949,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -2281,6 +2295,7 @@ packages:
 
   loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -2686,6 +2701,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@3.29.4:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,5 @@ packages:
   - 'examples/http-certification/assets/src/frontend'
   - 'examples/http-certification/custom-assets/src/frontend'
   - 'examples/http-certification/json-api/src/tests'
+  - 'examples/http-certification/custom-assets/src/tests'
+  - 'examples/http-certification/skip-certification/src/tests'


### PR DESCRIPTION
TT-425

- Adds some common code for skipping certification to the `ic-http-certification` library.
- Extends the custom asset canister example to show how to skip certification for certain paths, along with docs and an e2e test using PocketIC.
- Adds a new example to show how to skip certification for ALL responses, along with docs and an e2e test using PocketIC.

Inspired by this PR to skip certification for Candid UI: https://github.com/dfinity/candid/pull/571