### PR TITLE
feat(ic-asset-certification): integrate add_certificate_header into the library so consumers do not need to call it manually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "globset",
  "ic-certification 2.6.0",
  "ic-http-certification",
+ "ic-response-verification",
  "rstest",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "ic-certification 2.6.0",
  "ic-http-certification",
  "ic-response-verification",
+ "ic-response-verification-test-utils",
  "rstest",
  "thiserror",
 ]

--- a/examples/http-certification/assets/README.md
+++ b/examples/http-certification/assets/README.md
@@ -245,19 +245,15 @@ fn certify_all_assets() {
 
 ## Serving assets
 
-The `serve_asset` function is responsible for serving assets. It uses the `serve_asset` function from the `AssetRouter` to serve the assets. This function returns the `HttpResponse`, a witness (`HashTree`), and an expression path. The witness and expression path is used to generate the `IC-Certificate` header, which is added to the response before returning it. To add the `IC-Certificate` header to the response, the `add_v2_certificate_header` function from the `ic-http-certification` crate is used. This function takes the data certificate, response, witness, and expression path as arguments. The witness, expression path, and the canister's certified data are encoded using CBOR and then added to the response headers.
+The `serve_asset` function is responsible for serving assets. It uses the `serve_asset` function from the `AssetRouter` to serve the assets. This function returns an `HttpResponse` that can be returned to the caller.
 
 ```rust
 fn serve_asset(req: &HttpRequest) -> HttpResponse<'static> {
     ASSET_ROUTER.with_borrow(|asset_router| {
-        if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
-            add_v2_certificate_header(
-                data_certificate().expect("No data certificate available"),
-                &mut response,
-                &witness,
-                &expr_path,
-            );
-
+        if let Ok(response) = asset_router.serve_asset(
+            &data_certificate().expect("No data certificate available"),
+            req,
+        ) {
             response
         } else {
             ic_cdk::trap("Failed to serve asset");

--- a/examples/http-certification/assets/src/backend/src/lib.rs
+++ b/examples/http-certification/assets/src/backend/src/lib.rs
@@ -5,9 +5,7 @@ use ic_cdk::{
     api::{data_certificate, set_certified_data},
     *,
 };
-use ic_http_certification::{
-    utils::add_v2_certificate_header, HeaderField, HttpCertificationTree, HttpRequest, HttpResponse,
-};
+use ic_http_certification::{HeaderField, HttpCertificationTree, HttpRequest, HttpResponse};
 use include_dir::{include_dir, Dir};
 use std::{cell::RefCell, rc::Rc};
 
@@ -136,14 +134,10 @@ fn certify_all_assets() {
 // Handlers
 fn serve_asset(req: &HttpRequest) -> HttpResponse<'static> {
     ASSET_ROUTER.with_borrow(|asset_router| {
-        if let Ok((mut response, witness, expr_path)) = asset_router.serve_asset(req) {
-            add_v2_certificate_header(
-                data_certificate().expect("No data certificate available"),
-                &mut response,
-                &witness,
-                &expr_path,
-            );
-
+        if let Ok(response) = asset_router.serve_asset(
+            &data_certificate().expect("No data certificate available"),
+            req,
+        ) {
             response
         } else {
             ic_cdk::trap("Failed to serve asset");

--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -470,7 +470,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
             HTTP_TREE.with_borrow(|http_tree| {
                 add_v2_certificate_header(
-                    data_certificate().expect("No data certificate available"),
+                    &data_certificate().expect("No data certificate available"),
                     &mut response,
                     &http_tree
                         .witness(

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -324,7 +324,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
             HTTP_TREE.with_borrow(|http_tree| {
                 add_v2_certificate_header(
-                    data_certificate().expect("No data certificate available"),
+                    &data_certificate().expect("No data certificate available"),
                     &mut response,
                     &http_tree
                         .witness(

--- a/examples/http-certification/json-api/README.md
+++ b/examples/http-certification/json-api/README.md
@@ -381,7 +381,7 @@ fn query_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'stati
 
     HTTP_TREE.with_borrow(|http_tree| {
         add_v2_certificate_header(
-            data_certificate().expect("No data certificate available"),
+            &data_certificate().expect("No data certificate available"),
             &mut response,
             &http_tree
                 .witness(

--- a/examples/http-certification/json-api/src/backend/src/lib.rs
+++ b/examples/http-certification/json-api/src/backend/src/lib.rs
@@ -366,7 +366,7 @@ fn query_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'stati
 
     HTTP_TREE.with_borrow(|http_tree| {
         add_v2_certificate_header(
-            data_certificate().expect("No data certificate available"),
+            &data_certificate().expect("No data certificate available"),
             &mut response,
             &http_tree
                 .witness(

--- a/packages/ic-asset-certification/Cargo.toml
+++ b/packages/ic-asset-certification/Cargo.toml
@@ -22,3 +22,4 @@ globset = "0.4"
 
 [dev-dependencies]
 rstest.workspace = true
+ic-response-verification.workspace = true

--- a/packages/ic-asset-certification/Cargo.toml
+++ b/packages/ic-asset-certification/Cargo.toml
@@ -23,3 +23,4 @@ globset = "0.4"
 [dev-dependencies]
 rstest.workspace = true
 ic-response-verification.workspace = true
+ic-response-verification-test-utils.workspace = true

--- a/packages/ic-asset-certification/src/lib.rs
+++ b/packages/ic-asset-certification/src/lib.rs
@@ -485,16 +485,9 @@
 //!
 //! asset_router.certify_assets(vec![asset], vec![asset_config]).unwrap();
 //!
-//! let (mut response, witness, expr_path) = asset_router.serve_asset(&http_request).unwrap();
-//!
 //! // this should normally be retrieved using `ic_cdk::api::data_certificate()`.
 //! let data_certificate = vec![1, 2, 3];
-//! add_v2_certificate_header(
-//!     data_certificate,
-//!     &mut response,
-//!     &witness,
-//!     &expr_path,
-//! );
+//! let response = asset_router.serve_asset(&data_certificate, &http_request).unwrap();
 //!```
 //!
 //! ## Deleting assets

--- a/packages/ic-http-certification/src/utils/response_header.rs
+++ b/packages/ic-http-certification/src/utils/response_header.rs
@@ -52,7 +52,7 @@ use serde::Serialize;
 ///
 /// let witness = http_certification_tree.witness(&entry, request_url).unwrap();
 /// add_v2_certificate_header(
-///     data_certificate,
+///     &data_certificate,
 ///     &mut response,
 ///     &witness,
 ///     &expr_path
@@ -70,7 +70,7 @@ use serde::Serialize;
 /// );
 /// ```
 pub fn add_v2_certificate_header(
-    data_certificate: Vec<u8>,
+    data_certificate: &[u8],
     response: &mut HttpResponse,
     witness: &HashTree,
     expr_path: &[String],

--- a/packages/ic-response-verification-test-utils/src/encoding.rs
+++ b/packages/ic-response-verification-test-utils/src/encoding.rs
@@ -8,6 +8,10 @@ pub fn base64_encode(data: &[u8]) -> String {
     general_purpose::STANDARD.encode(data)
 }
 
+pub fn base64_decode(data: &str) -> Vec<u8> {
+    general_purpose::STANDARD.decode(data).unwrap()
+}
+
 pub fn hex_encode(data: &[u8]) -> String {
     hex::encode(data)
 }

--- a/packages/ic-response-verification/src/lib.rs
+++ b/packages/ic-response-verification/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod verification;
 pub use verification::*;
+
 mod error;
 pub use error::*;
 

--- a/packages/ic-response-verification/src/verification/mod.rs
+++ b/packages/ic-response-verification/src/verification/mod.rs
@@ -1,8 +1,10 @@
 //! The primary entry point for the repsonse verification API.
 
 mod body;
-mod certificate_header;
 mod certificate_header_field;
+
+mod certificate_header;
+pub use certificate_header::*;
 
 mod verify_request_response_pair;
 pub use verify_request_response_pair::*;


### PR DESCRIPTION
TT-436