### PR TITLE
feat(ic-asset-certification): remove certification of full long assets

### DIFF
--- a/packages/ic-certification/src/hash_tree/mod.rs
+++ b/packages/ic-certification/src/hash_tree/mod.rs
@@ -183,6 +183,14 @@ impl<Storage: AsRef<[u8]>> fmt::Debug for HashTree<Storage> {
     }
 }
 
+impl<Storage: AsRef<[u8]>> fmt::Display for HashTree<Storage> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashTree")
+            .field("root", &self.root)
+            .finish()
+    }
+}
+
 #[allow(dead_code)]
 impl<Storage: AsRef<[u8]>> HashTree<Storage> {
     /// Recomputes root hash of the full tree that this hash tree was constructed from.

--- a/packages/ic-certification/src/nested_rb_tree.rs
+++ b/packages/ic-certification/src/nested_rb_tree.rs
@@ -1,5 +1,5 @@
 use crate::{empty, fork, labeled, leaf, pruned, AsHashTree, Hash, HashTree, HashTreeNode, RbTree};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 
 pub trait NestedTreeKeyRequirements: Debug + Clone + AsRef<[u8]> + 'static {}
 pub trait NestedTreeValueRequirements: Debug + Clone + AsHashTree + 'static {}
@@ -15,6 +15,18 @@ pub enum NestedTree<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements
 impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> Default for NestedTree<K, V> {
     fn default() -> Self {
         NestedTree::Nested(RbTree::<K, NestedTree<K, V>>::new())
+    }
+}
+
+impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> Display for NestedTree<K, V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match &self {
+            NestedTree::Leaf(leaf) => {
+                format!("NestedTree::Leaf({})", hex::encode(leaf.root_hash()))
+            }
+            NestedTree::Nested(rb_tree) => format!("Nested({})", rb_tree),
+        };
+        write!(f, "{}", s)
     }
 }
 
@@ -443,6 +455,25 @@ mod tests {
     #[case::mismatched_fork_and_leaf(fork_a(), leaf_a())]
     fn merge_hash_trees_inconsistent_structure(#[case] lhs: HashTree, #[case] rhs: HashTree) {
         merge_hash_trees(lhs, rhs);
+    }
+
+    #[test]
+    fn should_display_labels_and_hex_hashes() {
+        let label_1 = "label 1";
+        let label_2 = "label 2";
+
+        let value_1 = [1, 2, 3, 4, 5];
+        let value_2 = [7, 8, 9, 10];
+
+        let mut tree: NestedTree<&str, Vec<u8>> = NestedTree::default();
+        tree.insert(&[label_1, label_2], value_1.to_vec());
+        tree.insert(&[label_2, label_1], value_2.to_vec());
+
+        let s = format!("{}", tree);
+        assert!(s.contains(label_1));
+        assert!(s.contains(label_2));
+        assert!(s.contains(&format!("0x{}", hex::encode(value_1))));
+        assert!(s.contains(&format!("0x{}", hex::encode(value_2))));
     }
 
     #[fixture]

--- a/packages/ic-certification/src/rb_tree/mod.rs
+++ b/packages/ic-certification/src/rb_tree/mod.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use std::borrow::Cow;
 use std::cmp::Ordering::{self, Equal, Greater, Less};
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Color {
@@ -341,6 +342,30 @@ where
             write!(f, "({:?}, {:?})", k, v)?;
         }
         write!(f, "]")
+    }
+}
+
+impl<K, V> Display for RbTree<K, V>
+where
+    K: 'static + AsRef<[u8]>,
+    V: 'static + AsHashTree,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        let mut first = true;
+        for (k, v) in self.iter() {
+            if !first {
+                write!(f, ", ")?;
+                first = false;
+            }
+            write!(
+                f,
+                "\n    (\"{}\", {})",
+                String::from_utf8_lossy(k.as_ref()),
+                v.as_hash_tree()
+            )?;
+        }
+        write!(f, "\n]")
     }
 }
 

--- a/packages/ic-http-certification/src/tree/certification_tree.rs
+++ b/packages/ic-http-certification/src/tree/certification_tree.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use ic_certification::{labeled, labeled_hash, merge_hash_trees, AsHashTree, HashTree, NestedTree};
 use ic_representation_independent_hash::Sha256Digest;
+use std::fmt::{Display, Formatter};
 
 type CertificationTree = NestedTree<CertificationTreePathSegment, Vec<u8>>;
 
@@ -16,6 +17,12 @@ type CertificationTree = NestedTree<CertificationTreePathSegment, Vec<u8>>;
 #[derive(Debug, Clone)]
 pub struct HttpCertificationTree {
     tree: CertificationTree,
+}
+
+impl Display for HttpCertificationTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "tree: {}", self.tree)
+    }
 }
 
 impl Default for HttpCertificationTree {


### PR DESCRIPTION
Remove additional certification of full long assets, as these are now served in certified chunks, and the certification of the full asset is implied by the certification of the chunks. This avoids having two different certified responses for a single request for a long asset.

Additionally, add human-readable implementations of Display-trait for HttpCertificationTree and related structs, to simplify debugging.