### PR TITLE
feat(ic-asset-certification): add certification for individual chunks

### DIFF
--- a/packages/ic-asset-certification/src/asset_router.rs
+++ b/packages/ic-asset-certification/src/asset_router.rs
@@ -568,6 +568,7 @@ impl<'content> AssetRouter<'content> {
                     encoding,
                     Some(range_begin),
                 )?;
+                self.tree.borrow_mut().insert(&response.tree_entry);
                 self.responses.insert(
                     RequestKey::new(&asset_url, encoding_str(encoding), Some(range_begin)),
                     response,

--- a/packages/ic-certification/src/rb_tree/mod.rs
+++ b/packages/ic-certification/src/rb_tree/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     hash_tree::{fork, fork_hash, labeled_hash, leaf_hash, Hash},
     labeled, leaf, pruned, HashTree, HashTreeNode,
 };
-use std::borrow::Cow;
 use std::cmp::Ordering::{self, Equal, Greater, Less};
+use std::{borrow::Cow, fmt::Debug};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Color {
@@ -331,16 +331,15 @@ where
     V: 'static + AsHashTree + std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        let mut first = true;
+        let mut list = f.debug_list();
         for (k, v) in self.iter() {
-            if !first {
-                write!(f, ", ")?;
-            }
-            first = false;
-            write!(f, "({:?}, {:?})", k, v)?;
+            list.entry(&format_args!(
+                "({}, {:#?})",
+                String::from_utf8_lossy(k.as_ref()),
+                v.as_hash_tree()
+            ));
         }
-        write!(f, "]")
+        list.finish()
     }
 }
 

--- a/packages/ic-http-certification/src/tree/certification_tree.rs
+++ b/packages/ic-http-certification/src/tree/certification_tree.rs
@@ -9,13 +9,20 @@ use crate::{
 };
 use ic_certification::{labeled, labeled_hash, merge_hash_trees, AsHashTree, HashTree, NestedTree};
 use ic_representation_independent_hash::Sha256Digest;
+use std::fmt::{Debug, Formatter};
 
 type CertificationTree = NestedTree<CertificationTreePathSegment, Vec<u8>>;
 
 /// A certification tree for generic HTTP requests.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HttpCertificationTree {
     tree: CertificationTree,
+}
+
+impl Debug for HttpCertificationTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "tree: {:#?}", self.tree)
+    }
 }
 
 impl Default for HttpCertificationTree {


### PR DESCRIPTION
Add certification for individual chunks to the certification tree.
Additionally, add human-readable implementations of `Debug`-trait for HttpCertificationTree and related structs, to simplify debugging.

This PR supersedes PR #384 