### PR TITLE
feat(ic-http-certification): add request method enum

### DIFF
--- a/examples/http-certification/custom-assets/README.md
+++ b/examples/http-certification/custom-assets/README.md
@@ -173,7 +173,7 @@ fn create_asset_response(
     let headers = get_asset_headers(additional_headers, body.len(), cel_expr);
 
     HttpResponse::builder()
-        .with_status_code(200)
+        .with_status_code(StatusCode::OK)
         .with_headers(headers)
         .with_body(body)
         .build()
@@ -569,7 +569,7 @@ fn create_uncertified_response() -> HttpResponse<'static> {
     );
 
     HttpResponse::builder()
-        .with_status_code(200)
+        .with_status_code(StatusCode::OK)
         .with_headers(headers)
         .with_body(body)
         .build()

--- a/examples/http-certification/upgrade-to-update-call/README.md
+++ b/examples/http-certification/upgrade-to-update-call/README.md
@@ -36,7 +36,7 @@ fn http_request() -> HttpResponse<'static> {
 #[update]
 fn http_request_update() -> HttpUpdateResponse<'static> {
     HttpResponse::builder()
-        .with_status_code(418)
+        .with_status_code(StatusCode::IM_A_TEAPOT)
         .with_body(b"I'm a teapot")
         .build_update()
 }

--- a/packages/ic-response-verification-wasm/src/request.rs
+++ b/packages/ic-response-verification-wasm/src/request.rs
@@ -1,4 +1,5 @@
-use ic_http_certification::HttpRequest;
+use ic_http_certification::{HttpRequest, Method};
+use std::str::FromStr;
 use wasm_bindgen::{prelude::*, JsCast};
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -60,7 +61,7 @@ pub fn request_from_js(req: JsValue) -> HttpRequest<'static> {
     }
 
     HttpRequest::builder()
-        .with_method(method)
+        .with_method(Method::from_str(&method).unwrap())
         .with_url(url)
         .with_headers(headers)
         .with_body(body)


### PR DESCRIPTION
I took a very similar approach here as I did for response status code. Thankfully there's a lot less sweeping changes in this case though.

Additionally I noticed that I missed some docs that should've been updated with the status code change, so I fixed them too.