### PR TITLE
chore: resolve elided lifetime warning in json-api example

### DIFF
--- a/examples/http-certification/json-api/src/backend/src/types.rs
+++ b/examples/http-certification/json-api/src/backend/src/types.rs
@@ -18,7 +18,7 @@ pub enum ApiResponse<'a, T = ()> {
 }
 
 impl<'a, T: Serialize> ApiResponse<'a, T> {
-    pub fn ok(data: &'a T) -> ApiResponse<T> {
+    pub fn ok(data: &'a T) -> ApiResponse<'a, T> {
         Self::Ok { data }
     }
 


### PR DESCRIPTION
# Motivation

When I copied the code over, I got following build warning:

```
warning: elided lifetime has a name
 --> src/orbiter/src/http/impls.rs:6:42
  |
5 | impl<'a, T: Serialize> ApiResponse<'a, T> {
  |      -- lifetime `'a` declared here
6 |     pub fn ok(data: &'a T) -> ApiResponse<T> {
  |                                          ^ this elided lifetime gets resolved as `'a`
  |
  = note: `#[warn(elided_named_lifetimes)]` on by default
```

Therefore thought about providing a PR to pass the lifetime along in the example.  