### PR TITLE
chore: bump sccache-actions to v0.0.9

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Build Cargo crates
         run: cargo build --release
@@ -52,7 +52,7 @@ jobs:
           dfx-version: 'auto'
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
 
         # Triggers installation of the Rust toolchain
         # Must be done before wasm-pack is installed

--- a/.github/workflows/commitizen.yml
+++ b/.github/workflows/commitizen.yml
@@ -8,7 +8,7 @@ jobs:
     name: check_commit_messages:required
     uses: dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@main
     with:
-      starting_commit: '4b3de72e9b2a1ea5b700851c25db6f42cb55e8fa'
+      target_branch: 'main'
 
   check_pr_title:
     name: check_pr_title:required

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -36,7 +36,7 @@ jobs:
         uses: dfinity/setup-dfx@main
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
 
         # Triggers installation of the Rust toolchain
         # Must be done before wasm-pack is installed

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: dfinity/ci-tools/actions/setup-pnpm@main
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Setup e2e Deps Cache
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: dfinity/setup-dfx@main
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
 
         # Triggers installation of the Rust toolchain
         # Must be done before wasm-pack is installed

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.24.3",
+  "dfx": "0.26.0",
   "output_env_file": ".env",
   "version": 1,
   "networks": {

--- a/examples/http-certification/assets/src/tests/jest.config.ts
+++ b/examples/http-certification/assets/src/tests/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
   verbose: true,
+  testTimeout: 30_000,
 };
 
 export default config;

--- a/examples/http-certification/assets/src/tests/src/http.spec.ts
+++ b/examples/http-certification/assets/src/tests/src/http.spec.ts
@@ -1,4 +1,4 @@
-import { Actor, PocketIc } from '@hadronous/pic';
+import { Actor, PocketIc, PocketIcServer } from '@dfinity/pic';
 import { Principal } from '@dfinity/principal';
 import {
   verifyRequestResponsePair,
@@ -25,6 +25,7 @@ interface Metrics {
 }
 
 describe('Assets', () => {
+  let picServer: PocketIcServer;
   let pic: PocketIc;
   let actor: Actor<_SERVICE>;
   let canisterId: Principal;
@@ -35,13 +36,21 @@ describe('Assets', () => {
   const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
   const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
 
+  beforeAll(async () => {
+    picServer = await PocketIcServer.start();
+  });
+
+  afterAll(async () => {
+    picServer.stop();
+  });
+
   beforeEach(async () => {
-    pic = await PocketIc.create();
+    pic = await PocketIc.create(picServer.getUrl());
     const fixture = await setupBackendCanister(pic, currentDate);
     actor = fixture.actor;
     canisterId = fixture.canisterId;
 
-    const subnets = pic.getApplicationSubnets();
+    const subnets = await pic.getApplicationSubnets();
     rootKey = await pic.getPubKey(subnets[0].id);
   });
 

--- a/examples/http-certification/assets/src/tests/src/wasm.ts
+++ b/examples/http-certification/assets/src/tests/src/wasm.ts
@@ -1,4 +1,4 @@
-import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { type CanisterFixture, type PocketIc } from '@dfinity/pic';
 import { resolve } from 'node:path';
 import {
   type _SERVICE,

--- a/examples/http-certification/custom-assets/src/tests/jest.config.ts
+++ b/examples/http-certification/custom-assets/src/tests/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
   verbose: true,
+  testTimeout: 30_000,
 };
 
 export default config;

--- a/examples/http-certification/custom-assets/src/tests/src/http.spec.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/http.spec.ts
@@ -1,4 +1,4 @@
-import { Actor, PocketIc } from '@hadronous/pic';
+import { Actor, PocketIc, PocketIcServer } from '@dfinity/pic';
 import { Principal } from '@dfinity/principal';
 import {
   verifyRequestResponsePair,
@@ -23,6 +23,7 @@ interface Metrics {
 }
 
 describe('Assets', () => {
+  let picServer: PocketIcServer;
   let pic: PocketIc;
   let actor: Actor<_SERVICE>;
   let canisterId: Principal;
@@ -33,13 +34,21 @@ describe('Assets', () => {
   const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
   const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
 
+  beforeAll(async () => {
+    picServer = await PocketIcServer.start();
+  });
+
+  afterAll(async () => {
+    picServer.stop();
+  });
+
   beforeEach(async () => {
-    pic = await PocketIc.create();
+    pic = await PocketIc.create(picServer.getUrl());
     const fixture = await setupBackendCanister(pic, currentDate);
     actor = fixture.actor;
     canisterId = fixture.canisterId;
 
-    const subnets = pic.getApplicationSubnets();
+    const subnets = await pic.getApplicationSubnets();
     rootKey = await pic.getPubKey(subnets[0].id);
   });
 

--- a/examples/http-certification/custom-assets/src/tests/src/wasm.ts
+++ b/examples/http-certification/custom-assets/src/tests/src/wasm.ts
@@ -1,4 +1,4 @@
-import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { type CanisterFixture, type PocketIc } from '@dfinity/pic';
 import { resolve } from 'node:path';
 import {
   type _SERVICE,

--- a/examples/http-certification/json-api/src/tests/jest.config.ts
+++ b/examples/http-certification/json-api/src/tests/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
   verbose: true,
+  testTimeout: 30_000,
 };
 
 export default config;

--- a/examples/http-certification/json-api/src/tests/src/todos.spec.ts
+++ b/examples/http-certification/json-api/src/tests/src/todos.spec.ts
@@ -1,4 +1,4 @@
-import { Actor, PocketIc } from '@hadronous/pic';
+import { Actor, PocketIc, PocketIcServer } from '@dfinity/pic';
 import { Principal } from '@dfinity/principal';
 import {
   verifyRequestResponsePair,
@@ -28,6 +28,7 @@ const MS_PER_S = 1e3;
 const S_PER_MIN = 60;
 
 describe('Todos', () => {
+  let picServer: PocketIcServer;
   let pic: PocketIc;
   let actor: Actor<_SERVICE>;
   let canisterId: Principal;
@@ -38,13 +39,21 @@ describe('Todos', () => {
   const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
   const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
 
+  beforeAll(async () => {
+    picServer = await PocketIcServer.start();
+  });
+
+  afterAll(async () => {
+    picServer.stop();
+  });
+
   beforeEach(async () => {
-    pic = await PocketIc.create();
+    pic = await PocketIc.create(picServer.getUrl());
     const fixture = await setupBackendCanister(pic, currentDate);
     actor = fixture.actor;
     canisterId = fixture.canisterId;
 
-    const subnets = pic.getApplicationSubnets();
+    const subnets = await pic.getApplicationSubnets();
     rootKey = await pic.getPubKey(subnets[0].id);
   });
 

--- a/examples/http-certification/json-api/src/tests/src/wasm.ts
+++ b/examples/http-certification/json-api/src/tests/src/wasm.ts
@@ -1,4 +1,4 @@
-import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { type CanisterFixture, type PocketIc } from '@dfinity/pic';
 import { resolve } from 'node:path';
 import {
   type _SERVICE,

--- a/examples/http-certification/skip-certification/src/tests/jest.config.ts
+++ b/examples/http-certification/skip-certification/src/tests/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
   verbose: true,
+  testTimeout: 30_000,
 };
 
 export default config;

--- a/examples/http-certification/skip-certification/src/tests/src/http.spec.ts
+++ b/examples/http-certification/skip-certification/src/tests/src/http.spec.ts
@@ -1,4 +1,4 @@
-import { Actor, PocketIc } from '@hadronous/pic';
+import { Actor, PocketIc, PocketIcServer } from '@dfinity/pic';
 import { Principal } from '@dfinity/principal';
 import {
   verifyRequestResponsePair,
@@ -21,6 +21,7 @@ interface Metrics {
 }
 
 describe('HTTP', () => {
+  let picServer: PocketIcServer;
   let pic: PocketIc;
   let actor: Actor<_SERVICE>;
   let canisterId: Principal;
@@ -31,13 +32,21 @@ describe('HTTP', () => {
   const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
   const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
 
+  beforeAll(async () => {
+    picServer = await PocketIcServer.start();
+  });
+
+  afterAll(async () => {
+    picServer.stop();
+  });
+
   beforeEach(async () => {
-    pic = await PocketIc.create();
+    pic = await PocketIc.create(picServer.getUrl());
     const fixture = await setupBackendCanister(pic, currentDate);
     actor = fixture.actor;
     canisterId = fixture.canisterId;
 
-    const subnets = pic.getApplicationSubnets();
+    const subnets = await pic.getApplicationSubnets();
     rootKey = await pic.getPubKey(subnets[0].id);
   });
 

--- a/examples/http-certification/skip-certification/src/tests/src/wasm.ts
+++ b/examples/http-certification/skip-certification/src/tests/src/wasm.ts
@@ -1,4 +1,4 @@
-import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { type CanisterFixture, type PocketIc } from '@dfinity/pic';
 import { resolve } from 'node:path';
 import {
   type _SERVICE,

--- a/examples/http-certification/upgrade-to-update-call/src/tests/jest.config.ts
+++ b/examples/http-certification/upgrade-to-update-call/src/tests/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   preset: 'ts-jest/presets/js-with-ts',
   testEnvironment: 'node',
   verbose: true,
+  testTimeout: 30_000,
 };
 
 export default config;

--- a/examples/http-certification/upgrade-to-update-call/src/tests/src/http.spec.ts
+++ b/examples/http-certification/upgrade-to-update-call/src/tests/src/http.spec.ts
@@ -1,4 +1,4 @@
-import { Actor, PocketIc } from '@hadronous/pic';
+import { Actor, PocketIc, PocketIcServer } from '@dfinity/pic';
 
 import {
   _SERVICE as RUST_SERVICE,
@@ -8,12 +8,21 @@ import { _SERVICE as MOTOKO_SERVICE } from '../../declarations/motoko-backend/ht
 import { setupMotokoBackendCanister, setupRustBackendCanister } from './wasm';
 
 describe('HTTP', () => {
+  let picServer: PocketIcServer;
   let pic: PocketIc;
   let rustActor: Actor<RUST_SERVICE>;
   let motokoActor: Actor<MOTOKO_SERVICE>;
 
+  beforeAll(async () => {
+    picServer = await PocketIcServer.start();
+  });
+
+  afterAll(async () => {
+    picServer.stop();
+  });
+
   beforeEach(async () => {
-    pic = await PocketIc.create();
+    pic = await PocketIc.create(picServer.getUrl());
 
     const rustFixture = await setupRustBackendCanister(pic);
     rustActor = rustFixture.actor;

--- a/examples/http-certification/upgrade-to-update-call/src/tests/src/wasm.ts
+++ b/examples/http-certification/upgrade-to-update-call/src/tests/src/wasm.ts
@@ -1,4 +1,4 @@
-import { type CanisterFixture, type PocketIc } from '@hadronous/pic';
+import { type CanisterFixture, type PocketIc } from '@dfinity/pic';
 import { resolve } from 'node:path';
 import {
   type _SERVICE as RUST_SERVICE,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dfinity/agent": "^1.0.1",
     "@dfinity/candid": "^1.0.1",
     "@dfinity/principal": "^1.0.1",
-    "@hadronous/pic": "0.6.1-b1",
+    "@dfinity/pic": "0.12.0",
     "@types/jest": "^29.5.13",
     "@types/node": "~22.10.2",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       '@dfinity/candid':
         specifier: ^1.0.1
         version: 1.0.1(@dfinity/principal@1.0.1)
+      '@dfinity/pic':
+        specifier: 0.12.0
+        version: 0.12.0(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/identity@1.0.1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)(@peculiar/webcrypto@1.4.5))(@dfinity/principal@1.0.1)
       '@dfinity/principal':
         specifier: ^1.0.1
         version: 1.0.1
-      '@hadronous/pic':
-        specifier: 0.6.1-b1
-        version: 0.6.1-b1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/identity@1.0.1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)(@peculiar/webcrypto@1.4.5))(@dfinity/principal@1.0.1)
       '@types/jest':
         specifier: ^29.5.13
         version: 29.5.13
@@ -364,6 +364,14 @@ packages:
       '@dfinity/principal': ^1.0.1
       '@peculiar/webcrypto': ^1.4.0
 
+  '@dfinity/pic@0.12.0':
+    resolution: {integrity: sha512-o5KwV1eonfwVZTMn0Fx9ZJxlqaD8b3CD4BVwStxtzAPKNYF5RgGh6G5e6g1IeKXgOCn+ZyxNHfplQuy0BYFilA==}
+    peerDependencies:
+      '@dfinity/agent': ^2.3.0
+      '@dfinity/candid': ^2.3.0
+      '@dfinity/identity': ^2.3.0
+      '@dfinity/principal': ^2.3.0
+
   '@dfinity/principal@1.0.1':
     resolution: {integrity: sha512-pCAuTLcvZEZ8fYgVzTVhfUfFGadxeWN4v2z8Q0rizeiqcHKhbJVfWUiXXjzPGG5lNz2DxKyUHQ/WS4UTbTaxvg==}
 
@@ -504,14 +512,6 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
-
-  '@hadronous/pic@0.6.1-b1':
-    resolution: {integrity: sha512-9e1qjZooTvY41jcHTNYnZp6JN81SgbeWTfqoo4CSp0Iuuv2aNfzZ1/kYvH88WEGs/HG8QUn/MMgs1Y3g0u5vZg==}
-    peerDependencies:
-      '@dfinity/agent': ^1.0.1
-      '@dfinity/candid': ^1.0.1
-      '@dfinity/identity': ^1.0.1
-      '@dfinity/principal': ^1.0.1
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -2619,6 +2619,14 @@ snapshots:
       '@peculiar/webcrypto': 1.4.5
       borc: 2.1.2
 
+  '@dfinity/pic@0.12.0(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/identity@1.0.1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)(@peculiar/webcrypto@1.4.5))(@dfinity/principal@1.0.1)':
+    dependencies:
+      '@dfinity/agent': 1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)
+      '@dfinity/candid': 1.0.1(@dfinity/principal@1.0.1)
+      '@dfinity/identity': 1.0.1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)(@peculiar/webcrypto@1.4.5)
+      '@dfinity/principal': 1.0.1
+      bip39: 3.1.0
+
   '@dfinity/principal@1.0.1':
     dependencies:
       '@noble/hashes': 1.5.0
@@ -2691,14 +2699,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
-
-  '@hadronous/pic@0.6.1-b1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/identity@1.0.1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)(@peculiar/webcrypto@1.4.5))(@dfinity/principal@1.0.1)':
-    dependencies:
-      '@dfinity/agent': 1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)
-      '@dfinity/candid': 1.0.1(@dfinity/principal@1.0.1)
-      '@dfinity/identity': 1.0.1(@dfinity/agent@1.0.1(@dfinity/candid@1.0.1(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1))(@dfinity/principal@1.0.1)(@peculiar/webcrypto@1.4.5)
-      '@dfinity/principal': 1.0.1
-      bip39: 3.1.0
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -76,7 +76,7 @@ dfx_start() {
 
   "$DFX" start --clean --background -qq --log file --logfile "./replica.log" -vv
 
-  DFX_REPLICA_PORT=$("$DFX" info replica-port)
+  DFX_REPLICA_PORT=$("$DFX" info webserver-port)
   DFX_REPLICA_ADDRESS="http://localhost:$DFX_REPLICA_PORT"
 
   echo "DFX local replica running at $DFX_REPLICA_ADDRESS."


### PR DESCRIPTION
To address a [breaking change](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts) in github and fix failing tests.