### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Build Cargo crates
         run: cargo build --release
@@ -41,18 +41,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup PNPM
-        uses: dfinity/ci-tools/actions/setup-pnpm@main
+        uses: dfinity/ci-tools/actions/setup-pnpm@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup DFX
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
         with:
           dfx-version: 'auto'
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
         # Triggers installation of the Rust toolchain
         # Must be done before wasm-pack is installed

--- a/.github/workflows/commitizen.yml
+++ b/.github/workflows/commitizen.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   check_commit_messages:
     name: check_commit_messages:required
-    uses: dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@main
+    uses: dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
     with:
       target_branch: 'main'
 
   check_pr_title:
     name: check_pr_title:required
-    uses: dfinity/ci-tools/.github/workflows/check-pr-title.yaml@main
+    uses: dfinity/ci-tools/.github/workflows/check-pr-title.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -12,31 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: generate_token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: dfinity/ci-tools/actions/setup-python@main
+        uses: dfinity/ci-tools/actions/setup-python@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup Commitizen
-        uses: dfinity/ci-tools/actions/setup-commitizen@main
+        uses: dfinity/ci-tools/actions/setup-commitizen@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup PNPM
-        uses: dfinity/ci-tools/actions/setup-pnpm@main
+        uses: dfinity/ci-tools/actions/setup-pnpm@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup DFX
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
         # Triggers installation of the Rust toolchain
         # Must be done before wasm-pack is installed
@@ -48,7 +48,7 @@ jobs:
 
       - name: Bump version
         id: bump_version
-        uses: dfinity/ci-tools/actions/bump-version@main
+        uses: dfinity/ci-tools/actions/bump-version@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Print Version
         run: echo "Bumping to version ${{ steps.bump_version.outputs.version }}"
@@ -62,7 +62,7 @@ jobs:
           pnpm build
 
       - name: Create Pull Request
-        uses: dfinity/ci-tools/actions/create-pr@main
+        uses: dfinity/ci-tools/actions/create-pr@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
         with:
           token: ${{ steps.generate_token.outputs.token }}
           branch_name: 'release/${{ steps.bump_version.outputs.version }}'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup PNPM
-        uses: dfinity/ci-tools/actions/setup-pnpm@main
+        uses: dfinity/ci-tools/actions/setup-pnpm@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Setup e2e Deps Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: tmp/
           key: ${{ runner.os }}-tmp

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
       - run: |
           cargo publish -p ic-certification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,28 +19,28 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Acquire short-lived crates.io token
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
 
       - name: Setup Python
-        uses: dfinity/ci-tools/actions/setup-python@main
+        uses: dfinity/ci-tools/actions/setup-python@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup Commitizen
-        uses: dfinity/ci-tools/actions/setup-commitizen@main
+        uses: dfinity/ci-tools/actions/setup-commitizen@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup PNPM
-        uses: dfinity/ci-tools/actions/setup-pnpm@main
+        uses: dfinity/ci-tools/actions/setup-pnpm@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Setup DFX
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
         # Triggers installation of the Rust toolchain
         # Must be done before wasm-pack is installed
@@ -57,7 +57,7 @@ jobs:
         run: pnpm build
 
       - name: Generate release notes
-        uses: dfinity/ci-tools/actions/generate-release-notes@main
+        uses: dfinity/ci-tools/actions/generate-release-notes@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main
 
       - name: Release ic-representation-independent-hash Cargo crate
         run: cargo publish -p ic-representation-independent-hash


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `mozilla-actions/sccache-action@v0.0.9` -> `mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9`
  - Version: v0.0.9 | Latest: v0.0.9 | Release age: 294d
  - Commit: https://github.com/mozilla-actions/sccache-action/commit/7d986dd989559c6ecdb630a3fd2557667be217ad

- `dfinity/ci-tools/actions/setup-pnpm@main` -> `dfinity/ci-tools/actions/setup-pnpm@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@main` -> `dfinity/ci-tools/.github/workflows/check-commit-messages.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/.github/workflows/check-pr-title.yaml@main` -> `dfinity/ci-tools/.github/workflows/check-pr-title.yaml@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 26d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `dfinity/ci-tools/actions/setup-python@main` -> `dfinity/ci-tools/actions/setup-python@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/actions/setup-commitizen@main` -> `dfinity/ci-tools/actions/setup-commitizen@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/actions/bump-version@main` -> `dfinity/ci-tools/actions/bump-version@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `dfinity/ci-tools/actions/create-pr@main` -> `dfinity/ci-tools/actions/create-pr@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad

- `actions/cache@v3` -> `actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0`
  - Version: v3.5.0 | Latest: v5.0.4 | Release age: 21d
  - Commit: https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c

- `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - Version: v6.0.2 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd

- `rust-lang/crates-io-auth-action@v1` -> `rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1`
  - Version: v1 | Latest: v1.0.4 | Release age: 16d
  - Commit: https://github.com/rust-lang/crates-io-auth-action/commit/b7e9a28eded4986ec6b1fa40eeee8f8f165559ec

- `dfinity/ci-tools/actions/generate-release-notes@main` -> `dfinity/ci-tools/actions/generate-release-notes@afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/ci-tools/commit/afeee4fbdc0683a88ec5a74ed7f59a2ce0e833ad


### Files modified

- `.github/workflows/build-and-test.yml`
- `.github/workflows/commitizen.yml`
- `.github/workflows/create-release-pr.yml`
- `.github/workflows/e2e-tests.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/release.yml`