### PR TITLE
feat: add utility for asset canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Feat
+
+- **ic-http-certification**: add `HttpCertification::response_only_prehashed` for creating certifications from pre-computed hashes
+- **ic-http-certification**: add `HttpCertificationTree::as_hash_tree` for serializing the full certification tree
+
 ## 3.1.0 (2026-02-03)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **ic-http-certification**: add `HttpCertification::response_only_prehashed` for creating certifications from pre-computed hashes
 - **ic-http-certification**: add `HttpCertificationTree::as_hash_tree` for serializing the full certification tree
+- **ic-http-certification**: add `response_hash_from_headers` for computing response hashes from pre-built header pairs
+- **ic-http-certification**: add `build_v2_certificate_header_value` for building the `IC-Certificate` header value as a `String`
+- **ic-http-certification**: add `cbor_encode_to_base64` utility for encoding values as base64(CBOR)
+- **ic-http-certification**: make `RESPONSE_STATUS_PSEUDO_HEADER_NAME` public
 
 ## 3.1.0 (2026-02-03)
 

--- a/examples/certification/certified-counter/src/backend/src/lib.rs
+++ b/examples/certification/certified-counter/src/backend/src/lib.rs
@@ -28,7 +28,7 @@ fn inc_count() {
         let mut tree = tree.borrow_mut();
         tree.insert("count", hash(&count.to_be_bytes()).to_vec());
 
-        ic_cdk::api::set_certified_data(&tree.root_hash());
+        ic_cdk::api::certified_data_set(&tree.root_hash());
     })
 }
 
@@ -62,7 +62,7 @@ fn get_count() -> CertifiedCounter {
     let witness = match get_count_witness() {
         Ok(tree) => tree,
         Err(err) => {
-            ic_cdk::trap(&format!("Error getting count witness: {:?}", err));
+            ic_cdk::trap(&format!("Error getting count witness: {err:?}"));
         }
     };
 

--- a/examples/http-certification/assets/src/backend/src/lib.rs
+++ b/examples/http-certification/assets/src/backend/src/lib.rs
@@ -1,10 +1,10 @@
-use api::canister_balance;
+use api::canister_cycle_balance;
 use ic_asset_certification::{
     Asset, AssetConfig, AssetEncoding, AssetFallbackConfig, AssetMap, AssetRedirectKind,
     AssetRouter,
 };
 use ic_cdk::{
-    api::{data_certificate, set_certified_data},
+    api::{certified_data_set, data_certificate},
     *,
 };
 use ic_http_certification::{
@@ -161,11 +161,11 @@ fn certify_all_assets() {
     ASSET_ROUTER.with_borrow_mut(|asset_router| {
         // 4. Certify the assets using the `certify_assets` function from the `ic-asset-certification` crate.
         if let Err(err) = asset_router.certify_assets(assets, asset_configs) {
-            ic_cdk::trap(&format!("Failed to certify assets: {}", err));
+            ic_cdk::trap(&format!("Failed to certify assets: {err}"));
         }
 
         // 5. Set the canister's certified data.
-        set_certified_data(&asset_router.root_hash());
+        certified_data_set(&asset_router.root_hash());
     });
 }
 
@@ -175,7 +175,7 @@ fn serve_metrics() -> HttpResponse<'static> {
         let metrics = Metrics {
             num_assets: asset_router.get_assets().len(),
             num_fallback_assets: asset_router.get_fallback_assets().len(),
-            cycle_balance: canister_balance(),
+            cycle_balance: canister_cycle_balance() as u64,
         };
         let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
         let headers = get_asset_headers(vec![

--- a/examples/http-certification/assets/src/backend/src/lib.rs
+++ b/examples/http-certification/assets/src/backend/src/lib.rs
@@ -20,7 +20,7 @@ use std::{cell::RefCell, rc::Rc};
 pub struct Metrics {
     pub num_assets: usize,
     pub num_fallback_assets: usize,
-    pub cycle_balance: u64,
+    pub cycle_balance: u128,
 }
 
 // Public methods
@@ -175,7 +175,7 @@ fn serve_metrics() -> HttpResponse<'static> {
         let metrics = Metrics {
             num_assets: asset_router.get_assets().len(),
             num_fallback_assets: asset_router.get_fallback_assets().len(),
-            cycle_balance: canister_cycle_balance() as u64,
+            cycle_balance: canister_cycle_balance(),
         };
         let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
         let headers = get_asset_headers(vec![

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -358,7 +358,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
 fn create_metrics_response() -> HttpResponse<'static> {
     let metrics = Metrics {
-        cycle_balance: canister_cycle_balance(),
+        cycle_balance: canister_cycle_balance() as u64,
     };
     let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
     let additional_headers = vec![

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -16,7 +16,7 @@ use std::{cell::RefCell, collections::HashMap};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Metrics {
-    pub cycle_balance: u64,
+    pub cycle_balance: u128,
 }
 
 // Public methods
@@ -358,7 +358,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
 fn create_metrics_response() -> HttpResponse<'static> {
     let metrics = Metrics {
-        cycle_balance: canister_cycle_balance() as u64,
+        cycle_balance: canister_cycle_balance(),
     };
     let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
     let additional_headers = vec![

--- a/examples/http-certification/custom-assets/src/backend/src/lib.rs
+++ b/examples/http-certification/custom-assets/src/backend/src/lib.rs
@@ -1,6 +1,6 @@
-use api::canister_balance;
+use api::canister_cycle_balance;
 use ic_cdk::{
-    api::{data_certificate, set_certified_data},
+    api::{certified_data_set, data_certificate},
     *,
 };
 use ic_http_certification::{
@@ -260,7 +260,7 @@ fn certify_asset_response(
 
 fn update_certified_data() {
     HTTP_TREE.with_borrow(|http_tree| {
-        set_certified_data(&http_tree.root_hash());
+        certified_data_set(&http_tree.root_hash());
     });
 }
 
@@ -358,7 +358,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
 
 fn create_metrics_response() -> HttpResponse<'static> {
     let metrics = Metrics {
-        cycle_balance: canister_balance(),
+        cycle_balance: canister_cycle_balance(),
     };
     let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
     let additional_headers = vec![

--- a/examples/http-certification/json-api/src/backend/src/lib.rs
+++ b/examples/http-certification/json-api/src/backend/src/lib.rs
@@ -1,5 +1,5 @@
 use ic_cdk::{
-    api::{data_certificate, set_certified_data},
+    api::{certified_data_set, data_certificate},
     *,
 };
 use ic_http_certification::{
@@ -210,7 +210,7 @@ fn certify_not_found_response() {
         http_tree.insert(&HttpCertificationTreeEntry::new(tree_path, &certification));
 
         // set the canister's certified data
-        set_certified_data(&http_tree.root_hash());
+        certified_data_set(&http_tree.root_hash());
     });
 }
 
@@ -262,7 +262,7 @@ fn certify_response(
         http_tree.insert(&HttpCertificationTreeEntry::new(tree_path, &certification));
 
         // set the canister's certified data
-        set_certified_data(&http_tree.root_hash());
+        certified_data_set(&http_tree.root_hash());
     });
 }
 

--- a/examples/http-certification/skip-certification/src/backend/src/lib.rs
+++ b/examples/http-certification/skip-certification/src/backend/src/lib.rs
@@ -1,6 +1,6 @@
-use api::canister_balance;
+use api::canister_cycle_balance;
 use ic_cdk::{
-    api::{data_certificate, set_certified_data},
+    api::{certified_data_set, data_certificate},
     *,
 };
 use ic_http_certification::{
@@ -16,7 +16,7 @@ pub struct Metrics {
 
 #[init]
 fn init() {
-    set_certified_data(&skip_certification_certified_data());
+    certified_data_set(&skip_certification_certified_data());
 }
 
 #[query]
@@ -30,7 +30,7 @@ fn http_request() -> HttpResponse<'static> {
 
 fn create_response() -> HttpResponse<'static> {
     let metrics = Metrics {
-        cycle_balance: canister_balance(),
+        cycle_balance: canister_cycle_balance() as u64,
     };
     let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
     let headers = vec![

--- a/examples/http-certification/skip-certification/src/backend/src/lib.rs
+++ b/examples/http-certification/skip-certification/src/backend/src/lib.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Metrics {
-    pub cycle_balance: u64,
+    pub cycle_balance: u128,
 }
 
 #[init]
@@ -30,7 +30,7 @@ fn http_request() -> HttpResponse<'static> {
 
 fn create_response() -> HttpResponse<'static> {
     let metrics = Metrics {
-        cycle_balance: canister_cycle_balance() as u64,
+        cycle_balance: canister_cycle_balance(),
     };
     let body = serde_json::to_vec(&metrics).expect("Failed to serialize metrics");
     let headers = vec![

--- a/packages/ic-certification-testing-wasm/src/certificate_builder.rs
+++ b/packages/ic-certification-testing-wasm/src/certificate_builder.rs
@@ -43,7 +43,7 @@ impl CertificateBuilder {
     ) -> CertificationTestResult<CertificateBuilder> {
         let canister_id_ranges = canister_id_ranges
             .into_iter()
-            .map(|v| serde_wasm_bindgen::from_value::<CanisterIdRange>(v))
+            .map(serde_wasm_bindgen::from_value::<CanisterIdRange>)
             .map(|v| v.map(|v| (v.low, v.high)))
             .collect::<Result<_, _>>()?;
 

--- a/packages/ic-http-certification/src/hash/response_hash.rs
+++ b/packages/ic-http-certification/src/hash/response_hash.rs
@@ -115,14 +115,31 @@ pub fn response_headers_hash(status_code: &u64, response_headers: &ResponseHeade
 /// [`representation_independent_hash`]). It appends the `:ic-cert-status` pseudo-header
 /// internally.
 ///
+/// The result is `SHA-256(header_hash || body_hash)` where `header_hash` is the
+/// representation-independent hash of the headers including the status pseudo-header.
+///
+/// # Expected input shape
+///
+/// To produce a hash that matches [`response_hash`], `certified_headers` must follow the
+/// same normalization that [`filter_response_headers`] applies:
+///
+/// - Header names must be ASCII-lowercased.
+/// - The `IC-Certificate` header must be excluded.
+/// - The `IC-CertificateExpression` header must be included (if present on the response).
+/// - The CEL `DefaultResponseCertification` filter (certified list or exclusion list)
+///   must already have been applied.
+/// - Values must be [`Value::String`] (no other [`Value`] variants are produced by
+///   [`response_headers_hash`] for header entries).
+///
+/// Callers that start from an [`HttpResponse`] and a [`DefaultResponseCertification`]
+/// should prefer [`response_hash`], which performs all of the above.
+///
 /// # Panics (debug builds)
 ///
 /// Debug-asserts that `certified_headers` does not already contain
 /// [`RESPONSE_STATUS_PSEUDO_HEADER_NAME`]. Passing it would produce duplicate keys
-/// and a hash that does not match [`response_hash`].
-///
-/// The result is `SHA-256(header_hash || body_hash)` where `header_hash` is the
-/// representation-independent hash of the headers including the status pseudo-header.
+/// and a hash that does not match [`response_hash`]. In release builds this check is
+/// skipped; callers must uphold the precondition themselves.
 pub fn response_hash_from_headers(
     certified_headers: &[(String, Value)],
     status_code: u16,
@@ -134,7 +151,8 @@ pub fn response_hash_from_headers(
             .any(|(k, _)| k == RESPONSE_STATUS_PSEUDO_HEADER_NAME),
         "certified_headers must not contain the status pseudo-header; it is added internally"
     );
-    let mut headers = Vec::from(certified_headers);
+    let mut headers = Vec::with_capacity(certified_headers.len() + 1);
+    headers.extend_from_slice(certified_headers);
     headers.push((
         RESPONSE_STATUS_PSEUDO_HEADER_NAME.into(),
         Value::Number(status_code.into()),

--- a/packages/ic-http-certification/src/hash/response_hash.rs
+++ b/packages/ic-http-certification/src/hash/response_hash.rs
@@ -8,7 +8,9 @@ pub const CERTIFICATE_HEADER_NAME: &str = "IC-Certificate";
 /// The name of the IC-CertificateExpression header.
 pub const CERTIFICATE_EXPRESSION_HEADER_NAME: &str = "IC-CertificateExpression";
 
-const RESPONSE_STATUS_PSEUDO_HEADER_NAME: &str = ":ic-cert-status";
+/// The pseudo-header name used for encoding the response status code in the
+/// [Representation Independent Hash](https://internetcomputer.org/docs/references/ic-interface-spec/#hash-of-map).
+pub const RESPONSE_STATUS_PSEUDO_HEADER_NAME: &str = ":ic-cert-status";
 
 /// Representation of response headers filtered by [filter_response_headers].
 #[derive(Debug)]
@@ -104,6 +106,33 @@ pub fn response_headers_hash(status_code: &u64, response_headers: &ResponseHeade
     ));
 
     representation_independent_hash(&headers_to_verify)
+}
+
+/// Computes the v2 response hash from pre-built header pairs, a status code, and a body hash.
+///
+/// This is a lower-level variant of [`response_hash`] that operates on headers already
+/// represented as `(String, Value)` pairs (the format used by
+/// [`representation_independent_hash`]). It appends the `:ic-cert-status` pseudo-header
+/// internally.
+///
+/// The result is `SHA-256(header_hash || body_hash)` where `header_hash` is the
+/// representation-independent hash of the headers including the status pseudo-header.
+pub fn response_hash_from_headers(
+    certified_headers: &[(String, Value)],
+    status_code: u16,
+    body_hash: &Hash,
+) -> Hash {
+    let mut headers = Vec::from(certified_headers);
+    headers.push((
+        RESPONSE_STATUS_PSEUDO_HEADER_NAME.into(),
+        Value::Number(status_code.into()),
+    ));
+    let header_hash = representation_independent_hash(&headers);
+    hash(
+        [header_hash.as_ref(), body_hash.as_ref()]
+            .concat()
+            .as_slice(),
+    )
 }
 
 /// Calculates the
@@ -430,6 +459,29 @@ mod tests {
         let result = response_hash(&response, &response_certification, Some(response_body_hash));
 
         assert_eq!(result, expected_hash.as_slice());
+    }
+
+    #[test]
+    fn response_hash_from_headers_matches_response_hash() {
+        let response_certification =
+            DefaultResponseCertification::certified_response_headers(vec![
+                "Accept-Encoding",
+                "Cache-Control",
+            ]);
+        let response = create_response(CERTIFIED_HEADERS_CEL_EXPRESSION);
+        let expected = response_hash(&response, &response_certification, None);
+
+        let filtered = filter_response_headers(&response, &response_certification);
+        let header_pairs: Vec<(String, Value)> = filtered
+            .headers
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect();
+        let body_hash = hash(response.body());
+        let result =
+            response_hash_from_headers(&header_pairs, response.status_code().as_u16(), &body_hash);
+
+        assert_eq!(result, expected);
     }
 
     fn create_response(cel_expression: &str) -> HttpResponse {

--- a/packages/ic-http-certification/src/hash/response_hash.rs
+++ b/packages/ic-http-certification/src/hash/response_hash.rs
@@ -115,6 +115,12 @@ pub fn response_headers_hash(status_code: &u64, response_headers: &ResponseHeade
 /// [`representation_independent_hash`]). It appends the `:ic-cert-status` pseudo-header
 /// internally.
 ///
+/// # Panics (debug builds)
+///
+/// Debug-asserts that `certified_headers` does not already contain
+/// [`RESPONSE_STATUS_PSEUDO_HEADER_NAME`]. Passing it would produce duplicate keys
+/// and a hash that does not match [`response_hash`].
+///
 /// The result is `SHA-256(header_hash || body_hash)` where `header_hash` is the
 /// representation-independent hash of the headers including the status pseudo-header.
 pub fn response_hash_from_headers(
@@ -122,6 +128,12 @@ pub fn response_hash_from_headers(
     status_code: u16,
     body_hash: &Hash,
 ) -> Hash {
+    debug_assert!(
+        !certified_headers
+            .iter()
+            .any(|(k, _)| k == RESPONSE_STATUS_PSEUDO_HEADER_NAME),
+        "certified_headers must not contain the status pseudo-header; it is added internally"
+    );
     let mut headers = Vec::from(certified_headers);
     headers.push((
         RESPONSE_STATUS_PSEUDO_HEADER_NAME.into(),

--- a/packages/ic-http-certification/src/lib.rs
+++ b/packages/ic-http-certification/src/lib.rs
@@ -622,5 +622,5 @@ pub mod utils;
 
 // https://github.com/la10736/rstest/tree/master/rstest_reuse#cavelets
 #[cfg(test)]
-#[allow(clippy::single_component_path_imports)]
+#[allow(clippy::single_component_path_imports, unused_imports)]
 use rstest_reuse;

--- a/packages/ic-http-certification/src/tree/certification.rs
+++ b/packages/ic-http-certification/src/tree/certification.rs
@@ -90,6 +90,19 @@ impl HttpCertification {
         }))
     }
 
+    /// Creates a response-only certification from pre-computed hashes.
+    ///
+    /// Unlike [`response_only`](HttpCertification::response_only), this constructor does not
+    /// require an [`HttpResponse`] and performs no validation. Use it when the CEL expression
+    /// hash and response hash have already been computed externally (e.g. via
+    /// [`response_hash_from_headers`](crate::response_hash_from_headers)).
+    pub fn response_only_prehashed(cel_expr_hash: Hash, response_hash: Hash) -> Self {
+        Self(HttpCertificationType::ResponseOnly {
+            cel_expr_hash,
+            response_hash,
+        })
+    }
+
     pub(crate) fn to_tree_path(self) -> Vec<Vec<u8>> {
         match self.0 {
             HttpCertificationType::Skip { cel_expr_hash } => vec![cel_expr_hash.to_vec()],
@@ -296,6 +309,32 @@ mod tests {
             result,
             HttpCertificationError::MultipleCertificateExpressionHeaders { expected } if expected == cel_expr.to_string()
         ));
+    }
+
+    #[rstest]
+    fn response_only_prehashed_matches_response_only() {
+        let cel_expr = DefaultCelBuilder::response_only_certification()
+            .with_response_certification(DefaultResponseCertification::certified_response_headers(
+                vec!["ETag", "Cache-Control"],
+            ))
+            .build();
+
+        let response = &HttpResponse::builder()
+            .with_status_code(StatusCode::OK)
+            .with_headers(vec![(
+                CERTIFICATE_EXPRESSION_HEADER_NAME.to_string(),
+                cel_expr.to_string(),
+            )])
+            .build();
+
+        let from_response = HttpCertification::response_only(&cel_expr, response, None).unwrap();
+
+        let cel_expr_hash = hash(cel_expr.to_string().as_bytes());
+        let resp_hash = response_hash(response, &cel_expr.response, None);
+        let from_prehashed = HttpCertification::response_only_prehashed(cel_expr_hash, resp_hash);
+
+        assert_eq!(from_prehashed, from_response);
+        assert_eq!(from_prehashed.to_tree_path(), from_response.to_tree_path());
     }
 
     #[rstest]

--- a/packages/ic-http-certification/src/tree/certification_tree.rs
+++ b/packages/ic-http-certification/src/tree/certification_tree.rs
@@ -75,6 +75,13 @@ impl HttpCertificationTree {
         self.tree.clear();
     }
 
+    /// Returns the full [HashTree] for this certification tree, wrapped under the `http_expr` label.
+    ///
+    /// This is useful for serializing the tree (e.g. CBOR) in response to a `certified_tree` query.
+    pub fn as_hash_tree(&self) -> HashTree {
+        labeled(PATH_PREFIX_BYTES, self.tree.as_hash_tree())
+    }
+
     /// Returns a pruned [HashTree] that will prove the presence of a given [HttpCertificationTreeEntry]
     /// in the full [HttpCertificationTree], without needing to return the full tree.
     ///
@@ -779,6 +786,41 @@ mod tests {
         path.insert(0, b"http_expr".to_vec());
 
         assert_matches!(witness.lookup_subtree(&path), SubtreeLookupResult::Found(_));
+    }
+
+    #[rstest]
+    fn test_as_hash_tree_contains_http_expr_label() {
+        let mut tree = HttpCertificationTree::default();
+
+        let cel_expr = DefaultCelBuilder::full_certification()
+            .with_response_certification(DefaultResponseCertification::response_header_exclusions(
+                vec![],
+            ))
+            .build();
+
+        let request = HttpRequest::get("/index.html").build();
+        let response = HttpResponse::ok(
+            b"hello",
+            vec![(
+                CERTIFICATE_EXPRESSION_HEADER_NAME.into(),
+                cel_expr.to_string(),
+            )],
+        )
+        .build();
+
+        let certification = HttpCertification::full(&cel_expr, &request, &response, None).unwrap();
+        let entry = HttpCertificationTreeEntry::new(
+            HttpCertificationPath::exact("/index.html"),
+            certification,
+        );
+        tree.insert(&entry);
+
+        let full_tree = tree.as_hash_tree();
+
+        assert_matches!(
+            full_tree.lookup_subtree(["http_expr", "index.html", "<$>"]),
+            SubtreeLookupResult::Found(_)
+        );
     }
 
     fn lookup_path_from_entry(entry: &HttpCertificationTreeEntry) -> Vec<Vec<u8>> {

--- a/packages/ic-http-certification/src/utils/response_header.rs
+++ b/packages/ic-http-certification/src/utils/response_header.rs
@@ -99,3 +99,32 @@ fn cbor_encode(value: &impl Serialize) -> Vec<u8> {
         .expect("Failed to serialize value");
     serializer.into_inner()
 }
+
+/// Serializes a value as self-describing CBOR and returns its base64 (standard alphabet) encoding.
+///
+/// This is useful for encoding `expr_path` and witness trees in the IC-Certificate header format.
+pub fn cbor_encode_to_base64(value: &impl Serialize) -> String {
+    BASE64.encode(cbor_encode(value))
+}
+
+/// Builds the value portion of the `IC-Certificate` response header.
+///
+/// Returns the full header value string in the format:
+/// `certificate=:…:, tree=:…:, expr_path=:…:, version=2`
+///
+/// Unlike [`add_v2_certificate_header`], this function returns the header value as a [`String`]
+/// rather than mutating an [`HttpResponse`]. The `expr_path_b64` argument is expected to already
+/// be a base64-encoded self-describing CBOR value (e.g. produced by [`cbor_encode_to_base64`]).
+pub fn build_v2_certificate_header_value(
+    data_certificate: &[u8],
+    witness: &HashTree,
+    expr_path_b64: &str,
+) -> String {
+    let witness = cbor_encode(witness);
+    format!(
+        "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+        BASE64.encode(data_certificate),
+        BASE64.encode(witness),
+        expr_path_b64,
+    )
+}


### PR DESCRIPTION
### Feat

- **ic-http-certification**: add `HttpCertification::response_only_prehashed` for creating certifications from pre-computed hashes
- **ic-http-certification**: add `HttpCertificationTree::as_hash_tree` for serializing the full certification tree
- **ic-http-certification**: add `response_hash_from_headers` for computing response hashes from pre-built header pairs
- **ic-http-certification**: add `build_v2_certificate_header_value` for building the `IC-Certificate` header value as a `String`
- **ic-http-certification**: add `cbor_encode_to_base64` utility for encoding values as base64(CBOR)
- **ic-http-certification**: make `RESPONSE_STATUS_PSEUDO_HEADER_NAME` public

Adds small utility functions that the asset canister needs to get rid of a bunch of code